### PR TITLE
Add option to disable the built-in processor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,25 @@ A [sample project](sample) for Android and iOS is available.
 The idea and more background about this library is covered in this
 [public talk](https://ralf-wondratschek.com/presentation/extending-kotlin-inject.html).
 
+## Advanced options
+
+### Disabling processors
+
+In some occasions the behavior of certain built-in symbol processors of kotlin-inject-anvil
+doesn't meet expectations or should be changed. The recommendation in this case is to disable
+the built-in processors and create your own. A processor can be disabled through KSP options, e.g.
+
+```groovy
+ksp {
+    arg("com.amazon.lastmile.kotlin.inject.anvil.processor.ContributesBindingProcessor", "disabled")
+}
+```
+
+The key of the option must match the fully qualified name of the symbol processor and the value
+must be `disabled`. All other values will keep the processor enabled. All built-in symbol
+processors are part of
+[this package](compiler/src/main/kotlin/com/amazon/lastmile/kotlin/inject/anvil/processor).
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/compiler/src/main/kotlin/com/amazon/lastmile/kotlin/inject/anvil/CompositeSymbolProcessor.kt
+++ b/compiler/src/main/kotlin/com/amazon/lastmile/kotlin/inject/anvil/CompositeSymbolProcessor.kt
@@ -5,7 +5,7 @@ import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.KSAnnotated
 
 internal class CompositeSymbolProcessor(
-    vararg symbolProcessors: SymbolProcessor,
+    symbolProcessors: Collection<SymbolProcessor>,
 ) : SymbolProcessor {
 
     private val symbolProcessors = symbolProcessors.sortedBy { it::class.qualifiedName }

--- a/compiler/src/test/kotlin/com/amazon/lastmile/kotlin/inject/anvil/Compilation.kt
+++ b/compiler/src/test/kotlin/com/amazon/lastmile/kotlin/inject/anvil/Compilation.kt
@@ -31,7 +31,9 @@ class Compilation internal constructor(
     /**
      * Configures the behavior of this compilation.
      */
-    fun configureAppPlatformProcessor(): Compilation = apply {
+    fun configureKotlinInjectAnvilProcessor(
+        processorOptions: Map<String, String> = emptyMap(),
+    ): Compilation = apply {
         checkNotCompiled()
         check(!processorsConfigured) { "Processor should not be configured twice." }
 
@@ -42,6 +44,8 @@ class Compilation internal constructor(
                 SymbolProcessorProvider::class.java,
                 SymbolProcessorProvider::class.java.classLoader,
             )
+
+            this.processorOptions.putAll(processorOptions)
 
             // Run KSP embedded directly within this kotlinc invocation
             withCompilation = true
@@ -83,8 +87,9 @@ class Compilation internal constructor(
     }
 
     /**
-     * Compiles the underlying [KotlinCompilation]. Note that if [configureAppPlatformProcessor] has not been called
-     * prior to this, it will be configured with default behavior.
+     * Compiles the underlying [KotlinCompilation]. Note that if
+     * [configureKotlinInjectAnvilProcessor] has not been called prior to this, it will be
+     * configured with default behavior.
      */
     fun compile(
         @Language("kotlin") vararg sources: String,
@@ -93,7 +98,7 @@ class Compilation internal constructor(
         checkNotCompiled()
         if (!processorsConfigured) {
             // Configure with default behaviors
-            configureAppPlatformProcessor()
+            configureKotlinInjectAnvilProcessor()
         }
         addSources(*sources)
         isCompiled = true
@@ -119,7 +124,7 @@ class Compilation internal constructor(
  * Helpful for testing code generators in unit tests end to end.
  *
  * This covers common cases, but is built upon reusable logic in [Compilation] and
- * [Compilation.configureAppPlatformProcessor]. Consider using those APIs if more
+ * [Compilation.configureKotlinInjectAnvilProcessor]. Consider using those APIs if more
  * advanced configuration is needed.
  */
 fun compile(
@@ -149,7 +154,7 @@ fun compile(
                 addPreviousCompilationResult(previousCompilationResult)
             }
         }
-        .configureAppPlatformProcessor()
+        .configureKotlinInjectAnvilProcessor()
         .compile(*sources)
         .also {
             if (exitCode == KotlinCompilation.ExitCode.OK) {

--- a/compiler/src/test/kotlin/com/amazon/lastmile/kotlin/inject/anvil/KotlinInjectExtensionSymbolProcessorProviderTest.kt
+++ b/compiler/src/test/kotlin/com/amazon/lastmile/kotlin/inject/anvil/KotlinInjectExtensionSymbolProcessorProviderTest.kt
@@ -1,0 +1,44 @@
+@file:OptIn(ExperimentalCompilerApi::class)
+
+package com.amazon.lastmile.kotlin.inject.anvil
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.jupiter.api.Test
+
+class KotlinInjectExtensionSymbolProcessorProviderTest {
+
+    @Test
+    fun `a processor can be disabled`() {
+        Compilation()
+            .configureKotlinInjectAnvilProcessor(
+                processorOptions = mapOf(
+                    "com.amazon.lastmile.kotlin.inject.anvil.processor.ContributesToProcessor" to
+                        "disabled",
+                ),
+            )
+            .compile(
+                """
+                package com.amazon.test
+    
+                import com.amazon.lastmile.kotlin.inject.anvil.ContributesTo
+    
+                @ContributesTo
+                @SingleInAppScope
+                interface ComponentInterface
+                """,
+            )
+            .run {
+                assertThat(exitCode).isEqualTo(OK)
+
+                // Throws the error because the generated component cannot be found.
+                assertFailure {
+                    componentInterface.generatedComponent
+                }.isInstanceOf<ClassNotFoundException>()
+            }
+    }
+}

--- a/compiler/src/test/kotlin/com/amazon/lastmile/kotlin/inject/anvil/processor/ContributesSubcomponentProcessorTest.kt
+++ b/compiler/src/test/kotlin/com/amazon/lastmile/kotlin/inject/anvil/processor/ContributesSubcomponentProcessorTest.kt
@@ -117,7 +117,7 @@ class ContributesSubcomponentProcessorTest {
                 addPreviousCompilationResult(previousResult2)
                 addPreviousCompilationResult(previousResult3)
             }
-            .configureAppPlatformProcessor()
+            .configureKotlinInjectAnvilProcessor()
             .compile(
                 """
                 package com.amazon.test


### PR DESCRIPTION
This allows us to change the default behavior of some annotations in case it the generated code doesn't provide the desired behavior.