### PR TITLE
Downgrade Kotlin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,13 +7,14 @@ auto-service = "1.1.1"
 auto-service-ksp = "1.2.0"
 detekt = "1.23.6"
 junit-jupiter = "5.10.3"
-kotlin = "2.0.0"
+kotlin = "1.9.24"
 kotlin-compile-testing = "0.5.1"
-# This is a snapshot build with the latest fixes.
-kotlin-inject = "0.7.2-20240710.214910-9"
-kotlin-poet = "1.18.1"
+kotlin-inject = "0.7.1"
+# This is a snapshot build with the latest fixes. We need that in the sample app.
+kotlin-inject-bugfix = "0.7.2-20240710.214910-9"
+kotlin-poet = "1.17.0"
 kotlinx-binaryCompatibilityValidator = "0.16.2"
-ksp = "2.0.0-1.0.23"
+ksp = "1.9.24-1.0.20"
 ktlint-binary = "1.2.1"
 ktlint-gradle = "12.1.1"
 maven-publish = "0.29.0"
@@ -32,6 +33,7 @@ kotlin-compile-testing-ksp = { module = "dev.zacsweers.kctfork:ksp", version.ref
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-gradle-plugin-api = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
 kotlin-inject-ksp = { module = "me.tatarka.inject:kotlin-inject-compiler-ksp", version.ref = "kotlin-inject" }
+kotlin-inject-ksp-bugfix = { module = "me.tatarka.inject:kotlin-inject-compiler-ksp", version.ref = "kotlin-inject-bugfix" }
 kotlin-inject-runtime = { module = "me.tatarka.inject:kotlin-inject-runtime", version.ref = "kotlin-inject" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinx-binaryCompatibilityValidator = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version.ref = "kotlinx-binaryCompatibilityValidator"}

--- a/runtime/api/runtime.klib.api
+++ b/runtime/api/runtime.klib.api
@@ -18,7 +18,7 @@ open annotation class com.amazon.lastmile.kotlin.inject.anvil.internal/Subcompon
 }
 
 open annotation class com.amazon.lastmile.kotlin.inject.anvil/ContributesBinding : kotlin/Annotation { // com.amazon.lastmile.kotlin.inject.anvil/ContributesBinding|null[0]
-    constructor <init>(kotlin.reflect/KClass<out kotlin/Annotation> = ..., kotlin.reflect/KClass<*> = ...) // com.amazon.lastmile.kotlin.inject.anvil/ContributesBinding.<init>|<init>(kotlin.reflect.KClass<out|kotlin.Annotation>;kotlin.reflect.KClass<*>){}[0]
+    constructor <init>(kotlin.reflect/KClass<out kotlin/Annotation> =..., kotlin.reflect/KClass<*> =...) // com.amazon.lastmile.kotlin.inject.anvil/ContributesBinding.<init>|<init>(kotlin.reflect.KClass<out|kotlin.Annotation>;kotlin.reflect.KClass<*>){}[0]
 
     final val boundType // com.amazon.lastmile.kotlin.inject.anvil/ContributesBinding.boundType|{}boundType[0]
         final fun <get-boundType>(): kotlin.reflect/KClass<*> // com.amazon.lastmile.kotlin.inject.anvil/ContributesBinding.boundType.<get-boundType>|<get-boundType>(){}[0]
@@ -39,7 +39,7 @@ open annotation class com.amazon.lastmile.kotlin.inject.anvil/ContributesTo : ko
 }
 
 open annotation class com.amazon.lastmile.kotlin.inject.anvil/MergeComponent : kotlin/Annotation { // com.amazon.lastmile.kotlin.inject.anvil/MergeComponent|null[0]
-    constructor <init>(kotlin/Array<kotlin.reflect/KClass<*>> = ...) // com.amazon.lastmile.kotlin.inject.anvil/MergeComponent.<init>|<init>(kotlin.Array<kotlin.reflect.KClass<*>>){}[0]
+    constructor <init>(kotlin/Array<kotlin.reflect/KClass<*>> =...) // com.amazon.lastmile.kotlin.inject.anvil/MergeComponent.<init>|<init>(kotlin.Array<kotlin.reflect.KClass<*>>){}[0]
 
     final val exclude // com.amazon.lastmile.kotlin.inject.anvil/MergeComponent.exclude|{}exclude[0]
         final fun <get-exclude>(): kotlin/Array<kotlin.reflect/KClass<*>> // com.amazon.lastmile.kotlin.inject.anvil/MergeComponent.exclude.<get-exclude>|<get-exclude>(){}[0]

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -18,9 +18,9 @@ android {
 }
 
 dependencies {
-    kspCommonMainMetadata libs.kotlin.inject.ksp
-    kspAndroid libs.kotlin.inject.ksp
-    kspIosSimulatorArm64 libs.kotlin.inject.ksp
+    kspCommonMainMetadata libs.kotlin.inject.ksp.bugfix
+    kspAndroid libs.kotlin.inject.ksp.bugfix
+    kspIosSimulatorArm64 libs.kotlin.inject.ksp.bugfix
 
     kspCommonMainMetadata project(':compiler')
     kspAndroid project(':compiler')


### PR DESCRIPTION
The upgrade to Kotlin 2.0 will happen later. The initial release will be with Kotlin 1.9.
