### PR TITLE
Support custom annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,39 @@ The idea and more background about this library is covered in this
 
 ## Advanced options
 
+### Custom symbol processors
+
+`kotlin-inject-anvil` is extensible with custom annotations and KSP symbol processors. In
+generated code you can reference annotations from `kotlin-inject-anvil` and that code will be
+picked up.
+
+For example, assume this annotation:
+```kotlin
+@Target(CLASS)
+@ContributingAnnotation
+annotation class MyCustomAnnotation
+```
+Note the `@ContributingAnnotation` marker, which is important for incremental compilation and
+multi-round support.
+
+A custom KSP symbol processor uses this annotation as trigger and generates following code:
+```
+@ContributesTo
+@SingleInAppScope
+interface MyCustomComponent {
+    @Provides
+    fun provideMyCustomType(): MyCustomType = ...
+}
+```
+This generated component interface `MyCustomComponent` will be picked up and merged in the
+corresponding component.
+
+Custom annotations and symbol processors are very powerful and allow you to adjust
+`kotlin-inject-anvil` to your needs and your codebase.
+
 ### Disabling processors
 
-In some occasions the behavior of certain built-in symbol processors of kotlin-inject-anvil
+In some occasions the behavior of certain built-in symbol processors of `kotlin-inject-anvil`
 doesn't meet expectations or should be changed. The recommendation in this case is to disable
 the built-in processors and create your own. A processor can be disabled through KSP options, e.g.
 

--- a/compiler/src/main/kotlin/com/amazon/lastmile/kotlin/inject/anvil/ContextAware.kt
+++ b/compiler/src/main/kotlin/com/amazon/lastmile/kotlin/inject/anvil/ContextAware.kt
@@ -50,10 +50,11 @@ internal interface ContextAware {
         }
     }
 
-    fun checkIsPublic(clazz: KSClassDeclaration) {
-        check(clazz.getVisibility() == Visibility.PUBLIC, clazz) {
-            "Contributed component interfaces must be public."
-        }
+    fun checkIsPublic(
+        clazz: KSClassDeclaration,
+        lazyMessage: () -> String = { "Contributed component interfaces must be public." },
+    ) {
+        check(clazz.getVisibility() == Visibility.PUBLIC, clazz, lazyMessage)
     }
 
     fun checkIsInterface(clazz: KSClassDeclaration) {

--- a/compiler/src/main/kotlin/com/amazon/lastmile/kotlin/inject/anvil/KotlinInjectExtensionSymbolProcessorProvider.kt
+++ b/compiler/src/main/kotlin/com/amazon/lastmile/kotlin/inject/anvil/KotlinInjectExtensionSymbolProcessorProvider.kt
@@ -5,6 +5,7 @@ import com.amazon.lastmile.kotlin.inject.anvil.processor.ContributesSubcomponent
 import com.amazon.lastmile.kotlin.inject.anvil.processor.ContributesSubcomponentProcessor
 import com.amazon.lastmile.kotlin.inject.anvil.processor.ContributesToProcessor
 import com.amazon.lastmile.kotlin.inject.anvil.processor.MergeComponentProcessor
+import com.amazon.lastmile.kotlin.inject.anvil.processor.extend.ContributingAnnotationProcessor
 import com.google.auto.service.AutoService
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
@@ -54,12 +55,12 @@ class KotlinInjectExtensionSymbolProcessorProvider : SymbolProcessorProvider {
                         codeGenerator = environment.codeGenerator,
                         logger = environment.logger,
                     ),
-                    contributingAnnotations = listOf(
-                        ContributesTo::class,
-                        ContributesBinding::class,
-                        ContributesSubcomponent::class,
-                        ContributesSubcomponent.Factory::class,
-                    ),
+                ),
+            )
+            addIfEnabled(
+                ContributingAnnotationProcessor(
+                    codeGenerator = environment.codeGenerator,
+                    logger = environment.logger,
                 ),
             )
         }

--- a/compiler/src/main/kotlin/com/amazon/lastmile/kotlin/inject/anvil/processor/extend/ContributingAnnotationProcessor.kt
+++ b/compiler/src/main/kotlin/com/amazon/lastmile/kotlin/inject/anvil/processor/extend/ContributingAnnotationProcessor.kt
@@ -1,0 +1,86 @@
+package com.amazon.lastmile.kotlin.inject.anvil.processor.extend
+
+import com.amazon.lastmile.kotlin.inject.anvil.ContextAware
+import com.amazon.lastmile.kotlin.inject.anvil.LOOKUP_PACKAGE
+import com.amazon.lastmile.kotlin.inject.anvil.addOriginAnnotation
+import com.amazon.lastmile.kotlin.inject.anvil.decapitalize
+import com.amazon.lastmile.kotlin.inject.anvil.extend.ContributingAnnotation
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.asClassName
+import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
+import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.writeTo
+import kotlin.reflect.KClass
+
+/**
+ * Generates the code for [ContributingAnnotation].
+ *
+ * In the lookup package [LOOKUP_PACKAGE] a new global property pointing to the annotation
+ * class is generated. To avoid name clashes the package name of the original annotation
+ * class is encoded in the property name, e.g.
+ * ```
+ * package com.amazon.test
+ *
+ * @ContributingAnnotation
+ * annotation class ContributesRenderer
+ * ```
+ * Will generate:
+ * ```
+ * package $LOOKUP_PACKAGE
+ *
+ * @Origin(ContributesRenderer::class)
+ * public val comAmazonTestContributesRenderer: KClass<ContributesRenderer>
+ *     = ContributesRenderer::class
+ * ```
+ */
+internal class ContributingAnnotationProcessor(
+    private val codeGenerator: CodeGenerator,
+    override val logger: KSPLogger,
+) : SymbolProcessor, ContextAware {
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        resolver
+            .getSymbolsWithAnnotation(ContributingAnnotation::class)
+            .filterIsInstance<KSClassDeclaration>()
+            .onEach {
+                checkIsPublic(it) {
+                    "Contributing annotations must be public."
+                }
+            }
+            .forEach {
+                generateProperty(it)
+            }
+
+        return emptyList()
+    }
+
+    private fun generateProperty(clazz: KSClassDeclaration) {
+        val componentClassName = ClassName(LOOKUP_PACKAGE, clazz.safeClassName)
+
+        val fileSpec = FileSpec.builder(componentClassName)
+            .addProperty(
+                PropertySpec
+                    .builder(
+                        name = clazz.safeClassName.decapitalize(),
+                        type = KClass::class.asClassName().parameterizedBy(clazz.toClassName()),
+                        modifiers = setOf(KModifier.PUBLIC),
+                    )
+                    .initializer("%T::class", clazz.toClassName())
+                    .addOriginatingKSFile(clazz.requireContainingFile())
+                    .addOriginAnnotation(clazz)
+                    .build(),
+            )
+            .build()
+
+        fileSpec.writeTo(codeGenerator, aggregating = false)
+    }
+}

--- a/compiler/src/test/kotlin/com/amazon/lastmile/kotlin/inject/anvil/Compilation.kt
+++ b/compiler/src/test/kotlin/com/amazon/lastmile/kotlin/inject/anvil/Compilation.kt
@@ -33,6 +33,7 @@ class Compilation internal constructor(
      */
     fun configureKotlinInjectAnvilProcessor(
         processorOptions: Map<String, String> = emptyMap(),
+        symbolProcessorProviders: Set<SymbolProcessorProvider> = emptySet(),
     ): Compilation = apply {
         checkNotCompiled()
         check(!processorsConfigured) { "Processor should not be configured twice." }
@@ -40,10 +41,11 @@ class Compilation internal constructor(
         processorsConfigured = true
 
         kotlinCompilation.configureKsp(useKsp2 = true) {
-            symbolProcessorProviders += ServiceLoader.load(
+            this.symbolProcessorProviders += ServiceLoader.load(
                 SymbolProcessorProvider::class.java,
                 SymbolProcessorProvider::class.java.classLoader,
             )
+            this.symbolProcessorProviders += symbolProcessorProviders
 
             this.processorOptions.putAll(processorOptions)
 

--- a/compiler/src/test/kotlin/com/amazon/lastmile/kotlin/inject/anvil/processor/MergeComponentProcessorTest.kt
+++ b/compiler/src/test/kotlin/com/amazon/lastmile/kotlin/inject/anvil/processor/MergeComponentProcessorTest.kt
@@ -11,6 +11,7 @@ import com.amazon.lastmile.kotlin.inject.anvil.LOOKUP_PACKAGE
 import com.amazon.lastmile.kotlin.inject.anvil.compile
 import com.amazon.lastmile.kotlin.inject.anvil.componentInterface
 import com.amazon.lastmile.kotlin.inject.anvil.inner
+import com.amazon.lastmile.kotlin.inject.anvil.mergedComponent
 import com.amazon.lastmile.kotlin.inject.anvil.otherScopeSource
 import com.tschuchort.compiletesting.JvmCompilationResult
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
@@ -407,13 +408,6 @@ class MergeComponentProcessorTest {
             )
         }
     }
-
-    private val Class<*>.mergedComponent: Class<*>
-        get() = classLoader.loadClass(
-            "$packageName." +
-                canonicalName.substring(packageName.length + 1).replace(".", "") +
-                "Merged",
-        )
 
     private val JvmCompilationResult.stringComponent: Class<*>
         get() = classLoader.loadClass("com.amazon.test.StringComponent")

--- a/compiler/src/test/kotlin/com/amazon/lastmile/kotlin/inject/anvil/processor/extend/ContributingAnnotationProcessorTest.kt
+++ b/compiler/src/test/kotlin/com/amazon/lastmile/kotlin/inject/anvil/processor/extend/ContributingAnnotationProcessorTest.kt
@@ -1,0 +1,67 @@
+@file:OptIn(ExperimentalCompilerApi::class)
+
+package com.amazon.lastmile.kotlin.inject.anvil.processor.extend
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import com.amazon.lastmile.kotlin.inject.anvil.compile
+import com.amazon.lastmile.kotlin.inject.anvil.contributesRenderer
+import com.amazon.lastmile.kotlin.inject.anvil.internal.Origin
+import com.amazon.lastmile.kotlin.inject.anvil.propertyAnnotations
+import com.amazon.lastmile.kotlin.inject.anvil.propertyMethodGetter
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.jupiter.api.Test
+import kotlin.reflect.KClass
+
+class ContributingAnnotationProcessorTest {
+
+    @Test
+    fun `a property is generated in the lookup package for a contributing annotation`() {
+        compile(
+            """
+            package com.amazon.test
+    
+            import com.amazon.lastmile.kotlin.inject.anvil.extend.ContributingAnnotation
+            import kotlin.annotation.AnnotationTarget.CLASS
+
+            @ContributingAnnotation
+            @Target(CLASS)
+            annotation class ContributesRenderer
+            """,
+        ) {
+            val propertyGetter = contributesRenderer.propertyMethodGetter
+
+            // The type parameter gets erased at runtime.
+            assertThat(propertyGetter.returnType.kotlin).isEqualTo(KClass::class)
+
+            // Checks the returned type.
+            assertThat(propertyGetter.invoke(null)).isEqualTo(contributesRenderer.kotlin)
+
+            // The @Origin annotation is present.
+            assertThat(
+                contributesRenderer.propertyAnnotations.filterIsInstance<Origin>().single().value,
+            ).isEqualTo(contributesRenderer.kotlin)
+        }
+    }
+
+    @Test
+    fun `a contributing annotation interface must be public`() {
+        compile(
+            """
+            package com.amazon.test
+    
+            import com.amazon.lastmile.kotlin.inject.anvil.extend.ContributingAnnotation
+            import kotlin.annotation.AnnotationTarget.CLASS
+
+            @ContributingAnnotation
+            @Target(CLASS)
+            internal annotation class ContributesRenderer
+            """,
+            exitCode = COMPILATION_ERROR,
+        ) {
+            assertThat(messages).contains("Contributing annotations must be public.")
+        }
+    }
+}

--- a/compiler/src/test/kotlin/com/amazon/lastmile/kotlin/inject/anvil/processor/extend/CustomSymbolProcessorTest.kt
+++ b/compiler/src/test/kotlin/com/amazon/lastmile/kotlin/inject/anvil/processor/extend/CustomSymbolProcessorTest.kt
@@ -1,0 +1,160 @@
+@file:OptIn(ExperimentalCompilerApi::class)
+
+package com.amazon.lastmile.kotlin.inject.anvil.processor.extend
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import com.amazon.lastmile.kotlin.inject.anvil.Compilation
+import com.amazon.lastmile.kotlin.inject.anvil.ContributesTo
+import com.amazon.lastmile.kotlin.inject.anvil.compile
+import com.amazon.lastmile.kotlin.inject.anvil.componentInterface
+import com.amazon.lastmile.kotlin.inject.anvil.mergedComponent
+import com.amazon.test.SingleInAppScope
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
+import com.squareup.kotlinpoet.ksp.writeTo
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
+import me.tatarka.inject.annotations.Provides
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.jupiter.api.Test
+
+class CustomSymbolProcessorTest {
+
+    @Test
+    fun `a custom symbol processor can generate code`() {
+        // The custom symbol processor will generate a component interface that is contributed
+        // to the final component. The generated component interface has a provider method
+        // for the type String.
+        Compilation()
+            .configureKotlinInjectAnvilProcessor(
+                symbolProcessorProviders = setOf(symbolProcessorProvider),
+            )
+            .compile(
+                """
+                package com.amazon.test
+        
+                import me.tatarka.inject.annotations.Component
+                import com.amazon.lastmile.kotlin.inject.anvil.MergeComponent
+                import com.amazon.lastmile.kotlin.inject.anvil.extend.ContributingAnnotation
+                import kotlin.annotation.AnnotationTarget.CLASS
+
+                @ContributingAnnotation
+                @Target(CLASS)
+                annotation class ContributesRenderer
+                
+                @ContributesRenderer
+                class Renderer
+    
+                @Component
+                @MergeComponent
+                @SingleInAppScope
+                interface ComponentInterface : ComponentInterfaceMerged {
+                    val string: String
+                }
+                """,
+            )
+            .run {
+                assertThat(exitCode).isEqualTo(OK)
+                assertThat(componentInterface.mergedComponent).isNotNull()
+            }
+    }
+
+    @Test
+    fun `a custom symbol processor can generate code with an annotation from a previous compilation`() {
+        // This will generate the property and the custom annotation will be picked up by
+        // MergeComponentProcessor in the 2nd compilation.
+        val previousCompilation = compile(
+            """
+            package com.amazon.test
+        
+            import com.amazon.lastmile.kotlin.inject.anvil.extend.ContributingAnnotation
+            import kotlin.annotation.AnnotationTarget.CLASS
+                
+            @ContributingAnnotation
+            @Target(CLASS)
+            annotation class ContributesRenderer
+            """,
+        )
+
+        // The custom symbol processor will generate a component interface that is contributed
+        // to the final component. The generated component interface has a provider method
+        // for the type String.
+        Compilation()
+            .configureKotlinInjectAnvilProcessor(
+                symbolProcessorProviders = setOf(symbolProcessorProvider),
+            )
+            .addPreviousCompilationResult(previousCompilation)
+            .compile(
+                """
+                package com.amazon.test
+        
+                import me.tatarka.inject.annotations.Component
+                import com.amazon.lastmile.kotlin.inject.anvil.MergeComponent
+                
+                @ContributesRenderer
+                class Renderer
+    
+                @Component
+                @MergeComponent
+                @SingleInAppScope
+                interface ComponentInterface : ComponentInterfaceMerged {
+                    val string: String
+                }
+                """,
+            )
+            .run {
+                assertThat(exitCode).isEqualTo(OK)
+                assertThat(componentInterface.mergedComponent).isNotNull()
+            }
+    }
+
+    private val symbolProcessorProvider = object : SymbolProcessorProvider {
+        override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+            return object : SymbolProcessor {
+                override fun process(resolver: Resolver): List<KSAnnotated> {
+                    resolver
+                        .getSymbolsWithAnnotation("com.amazon.test.ContributesRenderer")
+                        .filterIsInstance<KSClassDeclaration>()
+                        .forEach { clazz ->
+                            val componentClassName = ClassName(
+                                "com.amazon.test",
+                                "RendererComponent",
+                            )
+                            val fileSpec = FileSpec.builder(componentClassName)
+                                .addType(
+                                    TypeSpec
+                                        .interfaceBuilder(componentClassName)
+                                        .addOriginatingKSFile(clazz.containingFile!!)
+                                        .addAnnotation(ContributesTo::class)
+                                        .addAnnotation(SingleInAppScope::class)
+                                        .addFunction(
+                                            FunSpec
+                                                .builder("provideString")
+                                                .addAnnotation(Provides::class)
+                                                .returns(String::class)
+                                                .addCode("return \"renderer\"")
+                                                .build(),
+                                        )
+                                        .build(),
+                                )
+                                .build()
+
+                            fileSpec.writeTo(environment.codeGenerator, aggregating = false)
+                        }
+
+                    return emptyList()
+                }
+            }
+        }
+    }
+}

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -85,7 +85,7 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/estree@*", "@types/estree@^1.0.5":
+"@types/estree@*", "@types/estree@^1.0.0":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
@@ -102,7 +102,7 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@webassemblyjs/ast@1.12.1", "@webassemblyjs/ast@^1.12.1":
+"@webassemblyjs/ast@1.12.1", "@webassemblyjs/ast@^1.11.5":
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.12.1.tgz#bb16a0e8b1914f979f45864c23819cc3e3f0d4bb"
   integrity sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==
@@ -168,7 +168,7 @@
   resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.6.tgz#90f8bc34c561595fe156603be7253cdbcd0fab5a"
   integrity sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==
 
-"@webassemblyjs/wasm-edit@^1.12.1":
+"@webassemblyjs/wasm-edit@^1.11.5":
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz#9f9f3ff52a14c980939be0ef9d5df9ebc678ae3b"
   integrity sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==
@@ -203,7 +203,7 @@
     "@webassemblyjs/wasm-gen" "1.12.1"
     "@webassemblyjs/wasm-parser" "1.12.1"
 
-"@webassemblyjs/wasm-parser@1.12.1", "@webassemblyjs/wasm-parser@^1.12.1":
+"@webassemblyjs/wasm-parser@1.12.1", "@webassemblyjs/wasm-parser@^1.11.5":
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz#c47acb90e6f083391e3fa61d113650eea1e95937"
   integrity sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==
@@ -223,17 +223,17 @@
     "@webassemblyjs/ast" "1.12.1"
     "@xtuc/long" "4.2.2"
 
-"@webpack-cli/configtest@^2.1.1":
+"@webpack-cli/configtest@^2.1.0":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-2.1.1.tgz#3b2f852e91dac6e3b85fb2a314fb8bef46d94646"
   integrity sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==
 
-"@webpack-cli/info@^2.0.2":
+"@webpack-cli/info@^2.0.1":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-2.0.2.tgz#cc3fbf22efeb88ff62310cf885c5b09f44ae0fdd"
   integrity sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==
 
-"@webpack-cli/serve@^2.0.5":
+"@webpack-cli/serve@^2.0.3":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.5.tgz#325db42395cd49fe6c14057f9a900e427df8810e"
   integrity sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==
@@ -248,6 +248,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+abab@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
+  integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
+
 accepts@~1.3.4:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -256,7 +261,7 @@ accepts@~1.3.4:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
-acorn-import-assertions@^1.9.0:
+acorn-import-assertions@^1.7.6:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz#507276249d684797c84e0734ef84860334cfb1ac"
   integrity sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==
@@ -371,14 +376,14 @@ browser-stdout@1.3.1:
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
-browserslist@^4.21.10:
-  version "4.23.2"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.23.2.tgz#244fe803641f1c19c28c48c4b6ec9736eb3d32ed"
-  integrity sha512-qkqSyistMYdxAcw+CzbZwlBy8AGmS/eEWs+sEV5TnLRGDOL+C5M2EnH6tlZyg0YoAxGJAFKh61En9BR941GnHA==
+browserslist@^4.14.5:
+  version "4.23.3"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.23.3.tgz#debb029d3c93ebc97ffbc8d9cbb03403e227c800"
+  integrity sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==
   dependencies:
-    caniuse-lite "^1.0.30001640"
-    electron-to-chromium "^1.4.820"
-    node-releases "^2.0.14"
+    caniuse-lite "^1.0.30001646"
+    electron-to-chromium "^1.5.4"
+    node-releases "^2.0.18"
     update-browserslist-db "^1.1.0"
 
 buffer-from@^1.0.0:
@@ -407,10 +412,10 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-caniuse-lite@^1.0.30001640:
-  version "1.0.30001643"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001643.tgz#9c004caef315de9452ab970c3da71085f8241dbd"
-  integrity sha512-ERgWGNleEilSrHM6iUz/zJNSQTP8Mr21wDWpdgvRwcTXGAq6jMtOUPP4dqFPTdKqZ2wKTdtB+uucZ3MRpAUSmg==
+caniuse-lite@^1.0.30001646:
+  version "1.0.30001655"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001655.tgz#0ce881f5a19a2dcfda2ecd927df4d5c1684b982f"
+  integrity sha512-jRGVy3iSGO5Uutn2owlb5gR6qsGngTw9ZTb4ali9f3glshcNmJ2noam4Mo9zia5P9Dk3jNNydy7vQjuE5dQmfg==
 
 chalk@^4.1.0:
   version "4.1.2"
@@ -622,10 +627,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-electron-to-chromium@^1.4.820:
-  version "1.4.832"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.832.tgz#d25882ce0a9237577b039bffa124ecef1822003b"
-  integrity sha512-cTen3SB0H2SGU7x467NRe1eVcQgcuS6jckKfWJHia2eo0cHIGOqHoAxevIYZD4eRHcWjkvFzo93bi3vJ9W+1lA==
+electron-to-chromium@^1.5.4:
+  version "1.5.13"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz#1abf0410c5344b2b829b7247e031f02810d442e6"
+  integrity sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -658,7 +663,7 @@ engine.io@~6.5.2:
     engine.io-parser "~5.2.1"
     ws "~8.17.1"
 
-enhanced-resolve@^5.16.0:
+enhanced-resolve@^5.13.0:
   version "5.17.1"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz#67bfbbcc2f81d511be77d686a90267ef7f898a15"
   integrity sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==
@@ -873,16 +878,17 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
-  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
+glob@7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
+  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
     inherits "2"
-    minimatch "^5.0.1"
+    minimatch "^3.0.4"
     once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@^7.1.3, glob@^7.1.7:
   version "7.2.3"
@@ -903,7 +909,7 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.10, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6:
+graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.10, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -1124,19 +1130,19 @@ karma-sourcemap-loader@0.4.0:
   dependencies:
     graceful-fs "^4.2.10"
 
-karma-webpack@5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/karma-webpack/-/karma-webpack-5.0.1.tgz#4eafd31bbe684a747a6e8f3e4ad373e53979ced4"
-  integrity sha512-oo38O+P3W2mSPCSUrQdySSPv1LvPpXP+f+bBimNomS5sW+1V4SuhCuW8TfJzV+rDv921w2fDSDw0xJbPe6U+kQ==
+karma-webpack@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/karma-webpack/-/karma-webpack-5.0.0.tgz#2a2c7b80163fe7ffd1010f83f5507f95ef39f840"
+  integrity sha512-+54i/cd3/piZuP3dr54+NcFeKOPnys5QeM1IY+0SPASwrtHsliXUiCL50iW+K9WWA7RvamC4macvvQ86l3KtaA==
   dependencies:
     glob "^7.1.3"
-    minimatch "^9.0.3"
+    minimatch "^3.0.4"
     webpack-merge "^4.1.5"
 
-karma@6.4.3:
-  version "6.4.3"
-  resolved "https://registry.yarnpkg.com/karma/-/karma-6.4.3.tgz#763e500f99597218bbb536de1a14acc4ceea7ce8"
-  integrity sha512-LuucC/RE92tJ8mlCwqEoRWXP38UMAqpnq98vktmS9SznSoUPPUJQbc91dHcxcunROvfQjdORVA/YFviH+Xci9Q==
+karma@6.4.2:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/karma/-/karma-6.4.2.tgz#a983f874cee6f35990c4b2dcc3d274653714de8e"
+  integrity sha512-C6SU/53LB31BEgRg+omznBEMY4SjHU3ricV6zBcAe1EeILKkeScr+fZXtaI5WyDbkVowJxxAI6h73NcFPmXolQ==
   dependencies:
     "@colors/colors" "1.5.0"
     body-parser "^1.19.0"
@@ -1157,7 +1163,7 @@ karma@6.4.3:
     qjobs "^1.2.0"
     range-parser "^1.2.1"
     rimraf "^3.0.2"
-    socket.io "^4.7.2"
+    socket.io "^4.4.1"
     source-map "^0.6.1"
     tmp "^0.2.1"
     ua-parser-js "^0.7.30"
@@ -1252,20 +1258,6 @@ minimatch@^3.0.4, minimatch@^3.1.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
-  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
-  dependencies:
-    brace-expansion "^2.0.1"
-
-minimatch@^9.0.3:
-  version "9.0.5"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
-  integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
-  dependencies:
-    brace-expansion "^2.0.1"
-
 minimist@^1.2.3, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
@@ -1278,10 +1270,10 @@ mkdirp@^0.5.5:
   dependencies:
     minimist "^1.2.6"
 
-mocha@10.3.0:
-  version "10.3.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.3.0.tgz#0e185c49e6dccf582035c05fa91084a4ff6e3fe9"
-  integrity sha512-uF2XJs+7xSLsrmIvn37i/wnc91nw7XjOQB8ccyx5aEgdnohr7n+rEiZP23WkCYHjilR6+EboEnbq/ZQDz4LSbg==
+mocha@10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.2.0.tgz#1fd4a7c32ba5ac372e03a17eef435bd00e5c68b8"
+  integrity sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==
   dependencies:
     ansi-colors "4.1.1"
     browser-stdout "1.3.1"
@@ -1290,12 +1282,13 @@ mocha@10.3.0:
     diff "5.0.0"
     escape-string-regexp "4.0.0"
     find-up "5.0.0"
-    glob "8.1.0"
+    glob "7.2.0"
     he "1.2.0"
     js-yaml "4.1.0"
     log-symbols "4.1.0"
     minimatch "5.0.1"
     ms "2.1.3"
+    nanoid "3.3.3"
     serialize-javascript "6.0.0"
     strip-json-comments "3.1.1"
     supports-color "8.1.1"
@@ -1319,6 +1312,11 @@ ms@2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+nanoid@3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
+  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
+
 negotiator@0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
@@ -1329,7 +1327,7 @@ neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-node-releases@^2.0.14:
+node-releases@^2.0.18:
   version "2.0.18"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.18.tgz#f010e8d35e2fe8d6b2944f03f70213ecedc4ca3f"
   integrity sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==
@@ -1556,7 +1554,7 @@ safe-buffer@^5.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-schema-utils@^3.1.1, schema-utils@^3.2.0:
+schema-utils@^3.1.1, schema-utils@^3.1.2:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.3.0.tgz#f50a88877c3c01652a15b622ae9e9795df7a60fe"
   integrity sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==
@@ -1641,7 +1639,7 @@ socket.io-parser@~4.2.4:
     "@socket.io/component-emitter" "~3.1.0"
     debug "~4.3.1"
 
-socket.io@^4.7.2:
+socket.io@^4.4.1:
   version "4.7.5"
   resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-4.7.5.tgz#56eb2d976aef9d1445f373a62d781a41c7add8f8"
   integrity sha512-DmeAkF6cwM9jSfmp6Dr/5/mfMwb5Z5qRrSXLpo3Fq5SqyU8CMF15jIN4ZhfSwu35ksM1qmHZDQ/DK5XTccSTvA==
@@ -1659,11 +1657,12 @@ source-map-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"
   integrity sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==
 
-source-map-loader@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-5.0.0.tgz#f593a916e1cc54471cfc8851b905c8a845fc7e38"
-  integrity sha512-k2Dur7CbSLcAH73sBcIkV5xjPV4SzqO1NJ7+XaQl8if3VODDUj3FNchNGpqgJSKbvUfJuhVdv8K2Eu8/TNl2eA==
+source-map-loader@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-4.0.1.tgz#72f00d05f5d1f90f80974eda781cbd7107c125f2"
+  integrity sha512-oqXpzDIByKONVY8g1NUPOTQhe0UTU5bWUl32GSkqK2LjJj0HmwTMVKxcUip0RgAYhY1mqgOxjbQM48a0mmeNfA==
   dependencies:
+    abab "^2.0.6"
     iconv-lite "^0.6.3"
     source-map-js "^1.0.2"
 
@@ -1744,7 +1743,7 @@ tapable@^2.1.1, tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-terser-webpack-plugin@^5.3.10:
+terser-webpack-plugin@^5.3.7:
   version "5.3.10"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz#904f4c9193c6fd2a03f693a2150c62a92f40d199"
   integrity sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==
@@ -1790,10 +1789,10 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@5.4.3:
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.3.tgz#5c6fedd4c87bee01cd7a528a30145521f8e0feff"
-  integrity sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==
+typescript@5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
 
 ua-parser-js@^0.7.30:
   version "0.7.38"
@@ -1845,23 +1844,23 @@ void-elements@^2.0.0:
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   integrity sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==
 
-watchpack@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.1.tgz#29308f2cac150fa8e4c92f90e0ec954a9fed7fff"
-  integrity sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==
+watchpack@^2.4.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.2.tgz#2feeaed67412e7c33184e5a79ca738fbd38564da"
+  integrity sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==
   dependencies:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
-webpack-cli@5.1.4:
-  version "5.1.4"
-  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-5.1.4.tgz#c8e046ba7eaae4911d7e71e2b25b776fcc35759b"
-  integrity sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==
+webpack-cli@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-5.1.0.tgz#abc4b1f44b50250f2632d8b8b536cfe2f6257891"
+  integrity sha512-a7KRJnCxejFoDpYTOwzm5o21ZXMaNqtRlvS183XzGDUPRdVEzJNImcQokqYZ8BNTnk9DkKiuWxw75+DCCoZ26w==
   dependencies:
     "@discoveryjs/json-ext" "^0.5.0"
-    "@webpack-cli/configtest" "^2.1.1"
-    "@webpack-cli/info" "^2.0.2"
-    "@webpack-cli/serve" "^2.0.5"
+    "@webpack-cli/configtest" "^2.1.0"
+    "@webpack-cli/info" "^2.0.1"
+    "@webpack-cli/serve" "^2.0.3"
     colorette "^2.0.14"
     commander "^10.0.1"
     cross-spawn "^7.0.3"
@@ -1893,34 +1892,34 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@5.91.0:
-  version "5.91.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.91.0.tgz#ffa92c1c618d18c878f06892bbdc3373c71a01d9"
-  integrity sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==
+webpack@5.82.0:
+  version "5.82.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.82.0.tgz#3c0d074dec79401db026b4ba0fb23d6333f88e7d"
+  integrity sha512-iGNA2fHhnDcV1bONdUu554eZx+XeldsaeQ8T67H6KKHl2nUSwX8Zm7cmzOA46ox/X1ARxf7Bjv8wQ/HsB5fxBg==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
-    "@types/estree" "^1.0.5"
-    "@webassemblyjs/ast" "^1.12.1"
-    "@webassemblyjs/wasm-edit" "^1.12.1"
-    "@webassemblyjs/wasm-parser" "^1.12.1"
+    "@types/estree" "^1.0.0"
+    "@webassemblyjs/ast" "^1.11.5"
+    "@webassemblyjs/wasm-edit" "^1.11.5"
+    "@webassemblyjs/wasm-parser" "^1.11.5"
     acorn "^8.7.1"
-    acorn-import-assertions "^1.9.0"
-    browserslist "^4.21.10"
+    acorn-import-assertions "^1.7.6"
+    browserslist "^4.14.5"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.16.0"
+    enhanced-resolve "^5.13.0"
     es-module-lexer "^1.2.1"
     eslint-scope "5.1.1"
     events "^3.2.0"
     glob-to-regexp "^0.4.1"
-    graceful-fs "^4.2.11"
+    graceful-fs "^4.2.9"
     json-parse-even-better-errors "^2.3.1"
     loader-runner "^4.2.0"
     mime-types "^2.1.27"
     neo-async "^2.6.2"
-    schema-utils "^3.2.0"
+    schema-utils "^3.1.2"
     tapable "^2.1.1"
-    terser-webpack-plugin "^5.3.10"
-    watchpack "^2.4.1"
+    terser-webpack-plugin "^5.3.7"
+    watchpack "^2.4.0"
     webpack-sources "^3.2.3"
 
 which@^1.2.1:

--- a/runtime/api/android/runtime.api
+++ b/runtime/api/android/runtime.api
@@ -20,6 +20,9 @@ public abstract interface annotation class com/amazon/lastmile/kotlin/inject/anv
 	public abstract fun exclude ()[Ljava/lang/Class;
 }
 
+public abstract interface annotation class com/amazon/lastmile/kotlin/inject/anvil/extend/ContributingAnnotation : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class com/amazon/lastmile/kotlin/inject/anvil/internal/Origin : java/lang/annotation/Annotation {
 	public abstract fun value ()Ljava/lang/Class;
 }

--- a/runtime/api/jvm/runtime.api
+++ b/runtime/api/jvm/runtime.api
@@ -20,6 +20,9 @@ public abstract interface annotation class com/amazon/lastmile/kotlin/inject/anv
 	public abstract fun exclude ()[Ljava/lang/Class;
 }
 
+public abstract interface annotation class com/amazon/lastmile/kotlin/inject/anvil/extend/ContributingAnnotation : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class com/amazon/lastmile/kotlin/inject/anvil/internal/Origin : java/lang/annotation/Annotation {
 	public abstract fun value ()Ljava/lang/Class;
 }

--- a/runtime/api/runtime.klib.api
+++ b/runtime/api/runtime.klib.api
@@ -6,6 +6,10 @@
 // - Show declarations: true
 
 // Library unique name: <kotlin-inject-anvil:runtime>
+open annotation class com.amazon.lastmile.kotlin.inject.anvil.extend/ContributingAnnotation : kotlin/Annotation { // com.amazon.lastmile.kotlin.inject.anvil.extend/ContributingAnnotation|null[0]
+    constructor <init>() // com.amazon.lastmile.kotlin.inject.anvil.extend/ContributingAnnotation.<init>|<init>(){}[0]
+}
+
 open annotation class com.amazon.lastmile.kotlin.inject.anvil.internal/Origin : kotlin/Annotation { // com.amazon.lastmile.kotlin.inject.anvil.internal/Origin|null[0]
     constructor <init>(kotlin.reflect/KClass<*>) // com.amazon.lastmile.kotlin.inject.anvil.internal/Origin.<init>|<init>(kotlin.reflect.KClass<*>){}[0]
 

--- a/runtime/src/commonMain/kotlin/com/amazon/lastmile/kotlin/inject/anvil/extend/ContributingAnnotation.kt
+++ b/runtime/src/commonMain/kotlin/com/amazon/lastmile/kotlin/inject/anvil/extend/ContributingAnnotation.kt
@@ -1,0 +1,21 @@
+package com.amazon.lastmile.kotlin.inject.anvil.extend
+
+import kotlin.annotation.AnnotationTarget.ANNOTATION_CLASS
+
+/**
+ * kotlin-inject-anvil is extensible. You can you create your own annotations and write
+ * your own KSP processors to generate code. kotlin-inject-anvil supports multiple rounds and
+ * will pick up the generated code.
+ *
+ * When defining an annotation that will generate new code, make sure to annotate this
+ * annotation class with [ContributingAnnotation]. The annotation will generate a marker for
+ * kotlin-inject-anvil's merge phase and wait until all code has been generated in your custom
+ * symbol processor in multiple rounds, e.g.
+ * ```
+ * @ContributingAnnotation
+ * @Target(CLASS)
+ * annotation class ContributesCustomCode
+ * ```
+ */
+@Target(ANNOTATION_CLASS)
+public annotation class ContributingAnnotation

--- a/runtime/src/commonMain/kotlin/com/amazon/lastmile/kotlin/inject/anvil/internal/Origin.kt
+++ b/runtime/src/commonMain/kotlin/com/amazon/lastmile/kotlin/inject/anvil/internal/Origin.kt
@@ -1,6 +1,7 @@
 package com.amazon.lastmile.kotlin.inject.anvil.internal
 
 import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.PROPERTY
 import kotlin.reflect.KClass
 
 /**
@@ -8,7 +9,7 @@ import kotlin.reflect.KClass
  *
  * Marker for generated component interface to link their origin.
  */
-@Target(CLASS)
+@Target(CLASS, PROPERTY)
 public annotation class Origin(
     /**
      * Reference to the class that triggered generating this component interface.


### PR DESCRIPTION
Add support for custom annotations and symbol processors, which allow us to extend `kotlin-inject-anvil`. This will reduce boilerplate in codebases.