### PR TITLE
Add mingwX64() target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Add `mingwX64()` target to runtime.
+
 ### Changed
 
 ### Deprecated

--- a/runtime/api/runtime.klib.api
+++ b/runtime/api/runtime.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64, watchosX64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64, watchosX64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -28,6 +28,8 @@ kotlin {
     macosArm64()
     macosX64()
 
+    mingwX64()
+
     tvosArm64()
     tvosSimulatorArm64()
     tvosX64()


### PR DESCRIPTION
This adds a windows `mingwX64()` target to the runtime artifact


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
