### PR TITLE
Disallow contributing abstract classes as subcomponents

### DIFF
--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContextAware.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContextAware.kt
@@ -57,10 +57,11 @@ internal interface ContextAware {
         check(clazz.getVisibility() == Visibility.PUBLIC, clazz, lazyMessage)
     }
 
-    fun checkIsInterface(clazz: KSClassDeclaration) {
-        check(clazz.classKind == ClassKind.INTERFACE, clazz) {
-            "Only interfaces can be contributed."
-        }
+    fun checkIsInterface(
+        clazz: KSClassDeclaration,
+        lazyMessage: () -> String = { "Only interfaces can be contributed." },
+    ) {
+        check(clazz.classKind == ClassKind.INTERFACE, clazz, lazyMessage)
     }
 
     fun KSClassDeclaration.scope(): KSAnnotation {

--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesSubcomponentFactoryProcessor.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesSubcomponentFactoryProcessor.kt
@@ -75,6 +75,11 @@ internal class ContributesSubcomponentFactoryProcessor(
             .getSymbolsWithAnnotation(ContributesSubcomponent::class)
             .filterIsInstance<KSClassDeclaration>()
             .forEach {
+                checkIsInterface(it) {
+                    "Only interfaces can be contributed. If you have parameters on your " +
+                        "abstract class, then move them to the factory. See " +
+                        "@ContributesSubcomponent for more details."
+                }
                 checkHasFactoryInnerClass(it)
             }
 

--- a/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesSubcomponent.kt
+++ b/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesSubcomponent.kt
@@ -81,6 +81,25 @@ import kotlin.annotation.AnnotationTarget.CLASS
  *     return ChildComponentFinal.create(parentComponent, string, int)
  * }
  * ```
+ * Contributing abstract classes is not supported, e.g. the following is not supported and the
+ * parameter can be moved to the factory instead and then the abstract class can be converted to
+ * an interface.
+ * ```
+ * // Remove the parameter and convert the class to an interface. The parameter will be
+ * // generated due to the Factory having this parameter.
+ * @ContributesSubcomponent
+ * @SingleInRendererScope
+ * abstract class RendererComponent(
+ *     @get:Provides val string: String,
+ * ) {
+ *
+ *     @ContributesSubcomponent.Factory
+ *     @SingleInAppScope
+ *     interface Factory {
+ *         fun createRendererComponent(string: String): RendererComponent
+ *     }
+ * }
+ * ```
  */
 @Target(CLASS)
 public annotation class ContributesSubcomponent {


### PR DESCRIPTION
Explicitly disallow contributing abstract classes as subcomponents, because they're not needed and may cause problems during merging as Kotlin doesn't support multi-inheritance.

Fixes #17