### PR TITLE
Fix automatic releasing

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v4
 
       - name: Publish release
-        run: ./gradlew clean publish --no-build-cache --stacktrace --show-version
+        run: ./gradlew clean publishAndReleaseToMavenCentral --no-build-cache --stacktrace --show-version
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,8 @@ kotlin.code.style=official
 kotlin.mpp.stability.nowarn=true
 ksp.useKSP2=false
 
-SONATYPE_AUTOMATIC_RELEASE=true
+# This property does not work when setting up publishing through the DSL as we do.
+# SONATYPE_AUTOMATIC_RELEASE=true
 RELEASE_SIGNING_ENABLED=true
 
 POM_DESCRIPTION=Extensions for kotlin-inject to make dependency injection easier with a similar feature set as Anvil.


### PR DESCRIPTION
Use the Gradle task to release artifacts on Sonatype. The Gradle property does not work, when enabling publishing through the DSL as we do. The author of the plugin said:
> Are you using SONATYPE_HOST  or the dsl method to enable maven central publishing? If it's the latter then the automatic release Gradle property is ignored. publishToMavenCentral() has a second optional boolean parameter to enable automatic releases. There are some inconsistencies when mixing DSL and properties that I need to improve in the plugin