### PR TITLE
Move Gradle plugin versions

### DIFF
--- a/build-logic/build.gradle
+++ b/build-logic/build.gradle
@@ -1,14 +1,7 @@
-buildscript {
-    ext {
-        kotlinVersion = libs.versions.kotlin.asProvider().get()
-        ktlintVersion = libs.versions.ktlint.gradle.get()
-    }
-}
-
 plugins {
     id 'java-gradle-plugin'
-    alias libs.plugins.kotlin.jvm version "$kotlinVersion"
-    alias libs.plugins.ktlint version "$ktlintVersion"
+    alias libs.plugins.kotlin.jvm
+    alias libs.plugins.ktlint
 }
 
 repositories {

--- a/build-logic/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/gradle/BasePlugin.kt
+++ b/build-logic/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/gradle/BasePlugin.kt
@@ -15,6 +15,7 @@ internal class BasePlugin : Plugin<Project> {
         with(repositories) {
             mavenCentral()
             google()
+            gradlePluginPortal()
             maven {
                 it.url = URI.create("https://oss.sonatype.org/content/repositories/snapshots/")
             }

--- a/build.gradle
+++ b/build.gradle
@@ -1,26 +1,3 @@
-buildscript {
-    dependencies {
-        classpath libs.android.gradle.plugin
-        classpath libs.kotlin.gradle.plugin
-        classpath libs.kotlin.gradle.plugin.api
-        classpath libs.kotlinx.binaryCompatibilityValidator
-        classpath libs.ktlint.gradle.plugin
-        classpath libs.maven.publish.gradle.plugin
-        classpath libs.detekt.gradle.plugin
-        classpath libs.ksp.gradle.plugin
-    }
-
-    repositories {
-        mavenCentral()
-        google()
-        gradlePluginPortal()
-
-        maven {
-            url "https://oss.sonatype.org/content/repositories/snapshots/"
-        }
-    }
-}
-
 plugins {
     id 'software.amazon.root'
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,12 +46,12 @@ ktlint-gradle-plugin = { module = "org.jlleitschuh.gradle:ktlint-gradle", versio
 maven-publish-gradle-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "maven-publish" }
 
 [plugins]
-android-app = { id = "com.android.application" }
-android-library = { id = "com.android.library" }
-detekt = { id = "io.gitlab.arturbosch.detekt" }
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm" }
-kotlinx-binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator" }
-kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform" }
-ksp = { id = "com.google.devtools.ksp" }
-ktlint = { id = "org.jlleitschuh.gradle.ktlint" }
-maven-publish = { id = "com.vanniktech.maven.publish" }
+android-app = { id = "com.android.application", version.ref = "agp" }
+android-library = { id = "com.android.library", version.ref = "agp" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlinx-binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinx-binaryCompatibilityValidator" }
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-gradle" }
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,16 @@ pluginManagement {
     // Include the build-logic project first, otherwise the settings plugin from BunnyAndroidApi will mess with the classpath of build-logic
     // and break composite builds for it.
     includeBuild('build-logic')
+
+    repositories {
+        mavenCentral()
+        google()
+        gradlePluginPortal()
+
+        maven {
+            url "https://oss.sonatype.org/content/repositories/snapshots/"
+        }
+    }
 }
 
 rootProject.name = 'kotlin-inject-anvil'


### PR DESCRIPTION
Move the Gradle plugin versions into the .toml file to avoid the `buildScript` block in Gradle files.
