### PR TITLE
Add `@SingleIn` annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added a default scope annotation `@SingleIn`.
 - Allow specifying custom contributing annotations via KSP option instead of using `@ContributingAnnotation`.
 
 ### Changed
@@ -11,6 +12,8 @@
 ### Deprecated
 
 ### Removed
+
+- Removed `mingwX64()` target, because `kotlin-inject` doesn't support it.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ The project comes with a KSP plugin and a runtime module:
 dependencies {
     kspCommonMainMetadata "software.amazon.lastmile.kotlin.inject.anvil:compiler:$version"
     commonMainImplementation "software.amazon.lastmile.kotlin.inject.anvil:runtime:$version"
+
+    // Optional module for scope and qualifier annotations.
+    commonMainImplementation "software.amazon.lastmile.kotlin.inject.anvil:runtime-optional:$version"
 }
 ```
 For details how to setup KSP itself for multiplatform projects see the

--- a/build-logic/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/gradle/AndroidPlugin.kt
+++ b/build-logic/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/gradle/AndroidPlugin.kt
@@ -17,7 +17,8 @@ internal class AndroidPlugin : Plugin<Project> {
             val android = extensions.getByType(BaseExtension::class.java)
 
             android.namespace =
-                "software.amazon.lastmile.kotlin.inject.anvil${path.replace(':', '.')}"
+                "software.amazon.lastmile.kotlin.inject.anvil" +
+                path.replace(':', '.').replace('-', '.')
             android.compileSdkVersion(
                 libs.findVersion("android.compileSdk").get().requiredVersion.toInt(),
             )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ auto-service-annotations = { module = "com.google.auto.service:auto-service-anno
 auto-service-ksp = { module = "dev.zacsweers.autoservice:auto-service-ksp", version.ref = "auto-service-ksp" }
 detekt-gradle-plugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 graphviz-java = { module = "guru.nidi:graphviz-java", version = "0.18.1" }
+javax-inject = { group = "javax.inject", name = "javax.inject", version = "1" }
 junit-jupiter-bom = { module = "org.junit:junit-bom", version.ref = "junit-jupiter" }
 junit-jupiter-core = { module = "org.junit.jupiter:junit-jupiter" }
 junit-jupiter-launcher = { module = "org.junit.platform:junit-platform-launcher" }

--- a/runtime-optional/api/android/kotlin-inject-defaults.api
+++ b/runtime-optional/api/android/kotlin-inject-defaults.api
@@ -1,0 +1,4 @@
+public abstract interface annotation class software/amazon/lastmile/kotlin/inject/defaults/SingleIn : java/lang/annotation/Annotation {
+	public abstract fun scope ()Ljava/lang/Class;
+}
+

--- a/runtime-optional/api/android/runtime-optional.api
+++ b/runtime-optional/api/android/runtime-optional.api
@@ -1,0 +1,4 @@
+public abstract interface annotation class software/amazon/lastmile/kotlin/inject/anvil/SingleIn : java/lang/annotation/Annotation {
+	public abstract fun scope ()Ljava/lang/Class;
+}
+

--- a/runtime-optional/api/jvm/kotlin-inject-defaults.api
+++ b/runtime-optional/api/jvm/kotlin-inject-defaults.api
@@ -1,0 +1,4 @@
+public abstract interface annotation class software/amazon/lastmile/kotlin/inject/defaults/SingleIn : java/lang/annotation/Annotation {
+	public abstract fun scope ()Ljava/lang/Class;
+}
+

--- a/runtime-optional/api/jvm/runtime-optional.api
+++ b/runtime-optional/api/jvm/runtime-optional.api
@@ -1,0 +1,4 @@
+public abstract interface annotation class software/amazon/lastmile/kotlin/inject/anvil/SingleIn : java/lang/annotation/Annotation {
+	public abstract fun scope ()Ljava/lang/Class;
+}
+

--- a/runtime-optional/api/kotlin-inject-defaults.klib.api
+++ b/runtime-optional/api/kotlin-inject-defaults.klib.api
@@ -1,0 +1,14 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64, watchosX64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <kotlin-inject-anvil:kotlin-inject-defaults>
+open annotation class software.amazon.lastmile.kotlin.inject.defaults/SingleIn : kotlin/Annotation { // software.amazon.lastmile.kotlin.inject.defaults/SingleIn|null[0]
+    constructor <init>(kotlin.reflect/KClass<*>) // software.amazon.lastmile.kotlin.inject.defaults/SingleIn.<init>|<init>(kotlin.reflect.KClass<*>){}[0]
+
+    final val scope // software.amazon.lastmile.kotlin.inject.defaults/SingleIn.scope|{}scope[0]
+        final fun <get-scope>(): kotlin.reflect/KClass<*> // software.amazon.lastmile.kotlin.inject.defaults/SingleIn.scope.<get-scope>|<get-scope>(){}[0]
+}

--- a/runtime-optional/api/runtime-optional.klib.api
+++ b/runtime-optional/api/runtime-optional.klib.api
@@ -1,0 +1,14 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64, watchosX64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <kotlin-inject-anvil:runtime-optional>
+open annotation class software.amazon.lastmile.kotlin.inject.anvil/SingleIn : kotlin/Annotation { // software.amazon.lastmile.kotlin.inject.anvil/SingleIn|null[0]
+    constructor <init>(kotlin.reflect/KClass<*>) // software.amazon.lastmile.kotlin.inject.anvil/SingleIn.<init>|<init>(kotlin.reflect.KClass<*>){}[0]
+
+    final val scope // software.amazon.lastmile.kotlin.inject.anvil/SingleIn.scope|{}scope[0]
+        final fun <get-scope>(): kotlin.reflect/KClass<*> // software.amazon.lastmile.kotlin.inject.anvil/SingleIn.scope.<get-scope>|<get-scope>(){}[0]
+}

--- a/runtime-optional/build.gradle
+++ b/runtime-optional/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+    id 'software.amazon.lib.kmp'
+}
+
+dependencies {
+    commonMainImplementation libs.kotlin.inject.runtime
+
+    jvmAndAndroidCompileOnly libs.javax.inject
+}

--- a/runtime-optional/gradle.properties
+++ b/runtime-optional/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=runtime-optional
+POM_NAME=Kotlin Inject Anvil Runtime Optional

--- a/runtime-optional/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/SingleIn.kt
+++ b/runtime-optional/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/SingleIn.kt
@@ -1,0 +1,31 @@
+package software.amazon.lastmile.kotlin.inject.anvil
+
+import me.tatarka.inject.annotations.Scope
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.reflect.KClass
+
+/**
+ * A scope annotation for kotlin-inject to make classes singletons in the specified [scope],
+ * e.g. to make a class a singleton in the application scope you'd use:
+ * ```
+ * @Inject
+ * @SingleIn(AppScope::class)
+ * class MyClass(..) : SuperType {
+ *     ...
+ * }
+ * ```
+ *
+ * For Android and JVM targets this annotation is also marked with JSR-330 annotations and
+ * therefore the same annotation can be used for Dagger 2 and Anvil.
+ */
+@Scope
+@Retention(RUNTIME)
+@Target(CLASS, FUNCTION)
+public expect annotation class SingleIn(
+    /**
+     * The marker that identifies this scope.
+     */
+    val scope: KClass<*>,
+)

--- a/runtime-optional/src/jvmAndAndroid/kotlin/software/amazon/lastmile/kotlin/inject/anvil/SingleIn.kt
+++ b/runtime-optional/src/jvmAndAndroid/kotlin/software/amazon/lastmile/kotlin/inject/anvil/SingleIn.kt
@@ -1,0 +1,31 @@
+package software.amazon.lastmile.kotlin.inject.anvil
+
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.reflect.KClass
+
+/**
+ * A scope annotation for kotlin-inject to make classes singletons in the specified [scope],
+ * e.g. to make a class a singleton in the application scope you'd use:
+ * ```
+ * @Inject
+ * @SingleIn(AppScope::class)
+ * class MyClass(..) : SuperType {
+ *     ...
+ * }
+ * ```
+ *
+ * This annotation is also marked with JSR-330 annotations and therefore the same annotation
+ * can be used for Dagger 2 and Anvil.
+ */
+@me.tatarka.inject.annotations.Scope
+@javax.inject.Scope
+@Retention(RUNTIME)
+@Target(CLASS, FUNCTION)
+public actual annotation class SingleIn(
+    /**
+     * The marker that identifies this scope.
+     */
+    actual val scope: KClass<*>,
+)

--- a/runtime-optional/src/nonJvmAndAndroid/kotlin/software/amazon/lastmile/kotlin/inject/anvil/SingleIn.kt
+++ b/runtime-optional/src/nonJvmAndAndroid/kotlin/software/amazon/lastmile/kotlin/inject/anvil/SingleIn.kt
@@ -1,0 +1,28 @@
+package software.amazon.lastmile.kotlin.inject.anvil
+
+import me.tatarka.inject.annotations.Scope
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.reflect.KClass
+
+/**
+ * A scope annotation for kotlin-inject to make classes singletons in the specified [scope],
+ * e.g. to make a class a singleton in the application scope you'd use:
+ * ```
+ * @Inject
+ * @SingleIn(AppScope::class)
+ * class MyClass(..) : SuperType {
+ *     ...
+ * }
+ * ```
+ */
+@Scope
+@Retention(RUNTIME)
+@Target(CLASS, FUNCTION)
+public actual annotation class SingleIn(
+    /**
+     * The marker that identifies this scope.
+     */
+    actual val scope: KClass<*>,
+)

--- a/runtime/api/runtime.klib.api
+++ b/runtime/api/runtime.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64, watchosX64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64, watchosX64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,5 +18,6 @@ rootProject.name = 'kotlin-inject-anvil'
 
 include ':compiler'
 include ':runtime'
+include ':runtime-optional'
 include ':sample:app'
 include ':sample:lib'


### PR DESCRIPTION
Add the `@SingleIn` annotation to make onboarding kotlin-inject-anvil easier and standardize annotations across projects. This annotation can be reused for Dagger 2 and Anvil.

The module `:runtime-optional` has to be imported manually. Once all other implementations such as #1 are done, I'll update the documentation.

Contributes to #16.