### PR TITLE
Add `@ForScope` qualifier

### DIFF
--- a/runtime-optional/api/android/runtime-optional.api
+++ b/runtime-optional/api/android/runtime-optional.api
@@ -1,3 +1,7 @@
+public abstract interface annotation class software/amazon/lastmile/kotlin/inject/anvil/ForScope : java/lang/annotation/Annotation {
+	public abstract fun scope ()Ljava/lang/Class;
+}
+
 public abstract interface annotation class software/amazon/lastmile/kotlin/inject/anvil/SingleIn : java/lang/annotation/Annotation {
 	public abstract fun scope ()Ljava/lang/Class;
 }

--- a/runtime-optional/api/jvm/runtime-optional.api
+++ b/runtime-optional/api/jvm/runtime-optional.api
@@ -1,3 +1,7 @@
+public abstract interface annotation class software/amazon/lastmile/kotlin/inject/anvil/ForScope : java/lang/annotation/Annotation {
+	public abstract fun scope ()Ljava/lang/Class;
+}
+
 public abstract interface annotation class software/amazon/lastmile/kotlin/inject/anvil/SingleIn : java/lang/annotation/Annotation {
 	public abstract fun scope ()Ljava/lang/Class;
 }

--- a/runtime-optional/api/runtime-optional.klib.api
+++ b/runtime-optional/api/runtime-optional.klib.api
@@ -6,6 +6,13 @@
 // - Show declarations: true
 
 // Library unique name: <kotlin-inject-anvil:runtime-optional>
+open annotation class software.amazon.lastmile.kotlin.inject.anvil/ForScope : kotlin/Annotation { // software.amazon.lastmile.kotlin.inject.anvil/ForScope|null[0]
+    constructor <init>(kotlin.reflect/KClass<*>) // software.amazon.lastmile.kotlin.inject.anvil/ForScope.<init>|<init>(kotlin.reflect.KClass<*>){}[0]
+
+    final val scope // software.amazon.lastmile.kotlin.inject.anvil/ForScope.scope|{}scope[0]
+        final fun <get-scope>(): kotlin.reflect/KClass<*> // software.amazon.lastmile.kotlin.inject.anvil/ForScope.scope.<get-scope>|<get-scope>(){}[0]
+}
+
 open annotation class software.amazon.lastmile.kotlin.inject.anvil/SingleIn : kotlin/Annotation { // software.amazon.lastmile.kotlin.inject.anvil/SingleIn|null[0]
     constructor <init>(kotlin.reflect/KClass<*>) // software.amazon.lastmile.kotlin.inject.anvil/SingleIn.<init>|<init>(kotlin.reflect.KClass<*>){}[0]
 

--- a/runtime-optional/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ForScope.kt
+++ b/runtime-optional/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ForScope.kt
@@ -1,0 +1,34 @@
+package software.amazon.lastmile.kotlin.inject.anvil
+
+import me.tatarka.inject.annotations.Qualifier
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.reflect.KClass
+
+/**
+ * Commonly shared qualifier to tie types provided in multiple scopes to a particular [scope], e.g.
+ * ```
+ * @Inject
+ * @ContributesBinding(AppScope::class)
+ * @ForScope(AppScope::class)
+ * class UnauthenticatedHttpClient : HttpClient
+ *
+ * @Inject
+ * @ContributesBinding(LoggedInScope::class)
+ * @ForScope(LoggedInScope::class)
+ * class AuthenticatedHttpClient : HttpClient
+ * ```
+ *
+ * For Android and JVM targets this annotation is also marked with JSR-330 annotations and
+ * therefore the same annotation can be used for Dagger 2 and Anvil.
+ */
+@Qualifier
+@Retention(RUNTIME)
+@Target(CLASS, FUNCTION)
+public expect annotation class ForScope(
+    /**
+     * The marker that identifies this scope.
+     */
+    val scope: KClass<*>,
+)

--- a/runtime-optional/src/jvmAndAndroid/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ForScope.kt
+++ b/runtime-optional/src/jvmAndAndroid/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ForScope.kt
@@ -1,0 +1,34 @@
+package software.amazon.lastmile.kotlin.inject.anvil
+
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.reflect.KClass
+
+/**
+ * Commonly shared qualifier to tie types provided in multiple scopes to a particular [scope], e.g.
+ * ```
+ * @Inject
+ * @ContributesBinding(AppScope::class)
+ * @ForScope(AppScope::class)
+ * class UnauthenticatedHttpClient : HttpClient
+ *
+ * @Inject
+ * @ContributesBinding(LoggedInScope::class)
+ * @ForScope(LoggedInScope::class)
+ * class AuthenticatedHttpClient : HttpClient
+ * ```
+ *
+ * This annotation is also marked with JSR-330 annotations and therefore the same annotation
+ * can be used for Dagger 2 and Anvil.
+ */
+@me.tatarka.inject.annotations.Qualifier
+@javax.inject.Qualifier
+@Retention(RUNTIME)
+@Target(CLASS, FUNCTION)
+public actual annotation class ForScope(
+    /**
+     * The marker that identifies this scope.
+     */
+    actual val scope: KClass<*>,
+)

--- a/runtime-optional/src/nonJvmAndAndroid/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ForScope.kt
+++ b/runtime-optional/src/nonJvmAndAndroid/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ForScope.kt
@@ -1,0 +1,31 @@
+package software.amazon.lastmile.kotlin.inject.anvil
+
+import me.tatarka.inject.annotations.Qualifier
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.reflect.KClass
+
+/**
+ * Commonly shared qualifier to tie types provided in multiple scopes to a particular [scope], e.g.
+ * ```
+ * @Inject
+ * @ContributesBinding(AppScope::class)
+ * @ForScope(AppScope::class)
+ * class UnauthenticatedHttpClient : HttpClient
+ *
+ * @Inject
+ * @ContributesBinding(LoggedInScope::class)
+ * @ForScope(LoggedInScope::class)
+ * class AuthenticatedHttpClient : HttpClient
+ * ```
+ */
+@Qualifier
+@Retention(RUNTIME)
+@Target(CLASS, FUNCTION)
+public actual annotation class ForScope(
+    /**
+     * The marker that identifies this scope.
+     */
+    actual val scope: KClass<*>,
+)


### PR DESCRIPTION
Add the `@ForScope` annotation to make onboarding kotlin-inject-anvil easier and standardize annotations across projects. This annotation can be reused for Dagger 2 and Anvil.

Contributes to #16.
