### PR TITLE
Add `AppScope` marker class

### DIFF
--- a/runtime-optional/api/android/runtime-optional.api
+++ b/runtime-optional/api/android/runtime-optional.api
@@ -1,3 +1,6 @@
+public abstract class software/amazon/lastmile/kotlin/inject/anvil/AppScope {
+}
+
 public abstract interface annotation class software/amazon/lastmile/kotlin/inject/anvil/ForScope : java/lang/annotation/Annotation {
 	public abstract fun scope ()Ljava/lang/Class;
 }

--- a/runtime-optional/api/jvm/runtime-optional.api
+++ b/runtime-optional/api/jvm/runtime-optional.api
@@ -1,3 +1,6 @@
+public abstract class software/amazon/lastmile/kotlin/inject/anvil/AppScope {
+}
+
 public abstract interface annotation class software/amazon/lastmile/kotlin/inject/anvil/ForScope : java/lang/annotation/Annotation {
 	public abstract fun scope ()Ljava/lang/Class;
 }

--- a/runtime-optional/api/runtime-optional.klib.api
+++ b/runtime-optional/api/runtime-optional.klib.api
@@ -19,3 +19,5 @@ open annotation class software.amazon.lastmile.kotlin.inject.anvil/SingleIn : ko
     final val scope // software.amazon.lastmile.kotlin.inject.anvil/SingleIn.scope|{}scope[0]
         final fun <get-scope>(): kotlin.reflect/KClass<*> // software.amazon.lastmile.kotlin.inject.anvil/SingleIn.scope.<get-scope>|<get-scope>(){}[0]
 }
+
+abstract class software.amazon.lastmile.kotlin.inject.anvil/AppScope // software.amazon.lastmile.kotlin.inject.anvil/AppScope|null[0]

--- a/runtime-optional/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/AppScope.kt
+++ b/runtime-optional/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/AppScope.kt
@@ -1,0 +1,39 @@
+package software.amazon.lastmile.kotlin.inject.anvil
+
+/**
+ * Scope marker for the application scope, which gets created when the app launches. The
+ * application scope stays alive as long as the app itself.
+ *
+ * To make an object a singleton within the application scope, use this marker class in conjunction
+ * with [SingleIn], e.g.
+ * ```
+ * @Inject
+ * @SingleIn(AppScope::class)
+ * class MyClass : SuperType {
+ *     ...
+ * }
+ * ```
+ *
+ * To contribute a component interface to the application scope, use the `ContributesTo`
+ * annotation:
+ * ```
+ * @ContributesTo(AppScope::class)
+ * interface AbcComponent {
+ *     @Provides fun provideAbc(): Abc = ...
+ *
+ *     val abc: Abc
+ * }
+ * ```
+ *
+ * To contribute a binding to the application scope, use the `ContributesBinding` annotation:
+ * ```
+ * // Allows you to inject `Service` without adding any Dagger module.
+ * @Inject
+ * @ContributesBinding(AppScope::class)
+ * @SingleIn(AppScope::class)
+ * class ServiceImpl : Service {
+ *     ...
+ * }
+ * ```
+ */
+public abstract class AppScope private constructor()


### PR DESCRIPTION
Add the `AppScope` marker class to make onboarding kotlin-inject-anvil easier and standardize annotations across projects.

Contributes to #16.