### PR TITLE
Downgrade Kotlin Compile Testing

### DIFF
--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -31,8 +31,12 @@ dependencies {
     testRuntimeOnly libs.junit.jupiter.launcher
 
     // Added so that the SymbolProcessor is picked up in tests.
-    testImplementation libs.kotlin.inject.ksp
+    testImplementation(libs.kotlin.inject.ksp.bugfix) {
+        // TODO: Remove this when upgrading to Kotlin 2.0
+        exclude group: 'com.google.devtools.ksp', module: 'symbol-processing-api'
+    }
 
     // Bump transitive dependency.
-    testImplementation libs.ksp
+    // TODO: Enable with KSP2 and Kotlin 2.0 again.
+    // testImplementation libs.ksp
 }

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/Compilation.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/Compilation.kt
@@ -8,7 +8,10 @@ import com.tschuchort.compiletesting.JvmCompilationResult
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import com.tschuchort.compiletesting.addPreviousResultToClasspath
-import com.tschuchort.compiletesting.configureKsp
+import com.tschuchort.compiletesting.kspArgs
+import com.tschuchort.compiletesting.kspIncremental
+import com.tschuchort.compiletesting.kspWithCompilation
+import com.tschuchort.compiletesting.symbolProcessorProviders
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.JvmTarget
@@ -40,18 +43,17 @@ class Compilation internal constructor(
 
         processorsConfigured = true
 
-        kotlinCompilation.configureKsp(useKsp2 = true) {
+        with(kotlinCompilation) {
             this.symbolProcessorProviders += ServiceLoader.load(
                 SymbolProcessorProvider::class.java,
                 SymbolProcessorProvider::class.java.classLoader,
             )
             this.symbolProcessorProviders += symbolProcessorProviders
-
-            this.processorOptions.putAll(processorOptions)
+            this.kspArgs.putAll(processorOptions)
 
             // Run KSP embedded directly within this kotlinc invocation
-            withCompilation = true
-            incremental = true
+            kspWithCompilation = true
+            kspIncremental = true
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ auto-service-ksp = "1.2.0"
 detekt = "1.23.6"
 junit-jupiter = "5.10.3"
 kotlin = "1.9.24"
-kotlin-compile-testing = "0.5.1"
+kotlin-compile-testing = "0.4.1"
 kotlin-hierarchy = "1.1"
 kotlin-inject = "0.7.1"
 # This is a snapshot build with the latest fixes. We need that in the sample app.


### PR DESCRIPTION
Due to some incompatibilities we pulled in Kotlin Compile Testing for Kotlin 2.0 and our tests worked. However, we started seeing bugs with KSP2, in particular https://github.com/google/ksp/issues/2091

This project is using Kotlin 1.9, so better also stick with Kotlin Compile Testing and KSP for Kotlin 1.9.