### PR TITLE
Support scopes with parameters

### DIFF
--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     // Gives us access to annotations.
     implementation libs.kotlin.inject.runtime
 
+    testImplementation project(':runtime-optional')
     testImplementation libs.assertk
     testImplementation libs.kotlin.compile.testing.core
     testImplementation libs.kotlin.compile.testing.ksp

--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/MergeScope.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/MergeScope.kt
@@ -1,0 +1,157 @@
+package software.amazon.lastmile.kotlin.inject.anvil
+
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.ksp.toAnnotationSpec
+import com.squareup.kotlinpoet.ksp.toClassName
+
+/**
+ * Represents the destination of contributed types and which types should be merged during
+ * the merge phase. There is complexity to this problem, because `kotlin-inject` didn't
+ * support parameters for scopes initially and our Anvil extensions added support for that. Later,
+ * we started supporting parameters, which changed the API. E.g. one could use:
+ * ```
+ * @ContributesTo(AppScope::class)
+ * interface ContributedComponentInterface
+ *
+ * @Component
+ * @MergeComponent(AppScope::class)
+ * interface MergedComponent
+ * ```
+ * Or the old way:
+ * ```
+ * @ContributesTo
+ * @SingleInAppScope
+ * interface ContributedComponentInterface
+ *
+ * @Component
+ * @MergeComponent
+ * @SingleInAppScope
+ * interface MergedComponent
+ * ```
+ */
+internal sealed class MergeScope {
+    /**
+     * The fully qualified name of the annotation used as scope, e.g.
+     * ```
+     * @ContributesTo
+     * @SingleInAppScope
+     * interface Abc
+     * ```
+     * Note that the annotation itself is annotated with `@Scope`.
+     *
+     * The value is `null`, when only a marker is used, e.g.
+     * ```
+     * @ContributesTo(AppScope::class)
+     * interface Abc
+     * ```
+     *
+     * If the `scope` parameter is used and the argument is annotated with `@Scope`, then
+     * this value is non-null, e.g. for this:
+     * ```
+     * @ContributesBinding(scope = SingleInAppScope::class)
+     * class Binding : SuperType
+     * ```
+     */
+    abstract val annotationFqName: String?
+
+    /**
+     * A marker for a scope that isn't itself annotated with `@Scope`, e.g.
+     * ```
+     * @ContributesTo(AppScope::class)
+     * interface Abc
+     * ```
+     *
+     * The value is null, if no marker is used, e.g.
+     * ```
+     * @ContributesTo
+     * @SingleInAppScope
+     * interface Abc
+     * ```
+     *
+     * The value is also null, when the `scope` parameter is used and the argument is annotated
+     * with `@Scope`, e.g.
+     * ```
+     * @ContributesBinding(scope = SingleInAppScope::class)
+     * class Binding : SuperType
+     * ```
+     */
+    abstract val markerFqName: String?
+
+    /**
+     * A reference to the scope.
+     *
+     * [markerFqName] is preferred, because it allows us to decouple contributions from
+     * kotlin-inject's scoping mechanism. E.g. imagine someone using `@Singleton` as a scope, and
+     * they'd like to adopt kotlin-inject-anvil with `@ContributesTo(AppScope::class)`. Because we
+     * prefer the marker, this would be supported.
+     */
+    val fqName: String get() = requireNotNull(markerFqName ?: annotationFqName)
+
+    abstract fun toAnnotationSpec(): AnnotationSpec
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is MergeScope) return false
+
+        if (fqName != other.fqName) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return fqName.hashCode()
+    }
+
+    private class MarkerBasedMergeScope(
+        override val annotationFqName: String,
+        override val markerFqName: String?,
+        private val ksAnnotation: KSAnnotation,
+    ) : MergeScope() {
+        override fun toAnnotationSpec(): AnnotationSpec {
+            return ksAnnotation.toAnnotationSpec()
+        }
+    }
+
+    private class AnnotationBasedMergeScope(
+        override val annotationFqName: String?,
+        override val markerFqName: String?,
+        private val ksType: KSType,
+    ) : MergeScope() {
+        override fun toAnnotationSpec(): AnnotationSpec {
+            return AnnotationSpec.builder(ksType.toClassName()).build()
+        }
+    }
+
+    companion object {
+        operator fun invoke(
+            contextAware: ContextAware,
+            annotationType: KSType?,
+            markerType: KSType?,
+        ): MergeScope {
+            val nonNullType = contextAware.requireNotNull(markerType ?: annotationType, null) {
+                "Couldn't determine scope. No scope annotation nor marker found."
+            }
+
+            return AnnotationBasedMergeScope(
+                annotationFqName = annotationType?.declaration?.requireQualifiedName(contextAware),
+                markerFqName = markerType?.declaration?.requireQualifiedName(contextAware),
+                ksType = nonNullType,
+            )
+        }
+
+        operator fun invoke(
+            contextAware: ContextAware,
+            ksAnnotation: KSAnnotation,
+        ): MergeScope {
+            return MarkerBasedMergeScope(
+                annotationFqName = ksAnnotation.annotationType.resolve().declaration
+                    .requireQualifiedName(contextAware),
+                markerFqName = ksAnnotation.scopeParameter(contextAware)?.declaration
+                    ?.requireQualifiedName(contextAware),
+                ksAnnotation = ksAnnotation,
+            )
+        }
+    }
+}

--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesSubcomponentFactoryProcessor.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesSubcomponentFactoryProcessor.kt
@@ -12,7 +12,6 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
-import com.squareup.kotlinpoet.ksp.toAnnotationSpec
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.writeTo
 import software.amazon.lastmile.kotlin.inject.anvil.ContextAware
@@ -46,7 +45,6 @@ import software.amazon.lastmile.kotlin.inject.anvil.internal.Subcomponent
  * ```
  * package $LOOKUP_PACKAGE
  *
- * @ParentScope
  * @Origin(Subcomponent.Factory::class)
  * @Subcomponent
  * interface SoftwareAmazonTestSubcomponentFactory : Subcomponent.Factory
@@ -66,6 +64,7 @@ internal class ContributesSubcomponentFactoryProcessor(
                 checkIsPublic(it)
                 checkInnerClass(it)
                 checkSingleFunction(it)
+                checkHasScope(it)
             }
             .forEach {
                 generateComponentInterfaceForFactory(it)
@@ -88,14 +87,12 @@ internal class ContributesSubcomponentFactoryProcessor(
 
     private fun generateComponentInterfaceForFactory(factory: KSClassDeclaration) {
         val componentClassName = ClassName(LOOKUP_PACKAGE, factory.safeClassName)
-        val scope = factory.scope()
 
         val fileSpec = FileSpec.builder(componentClassName)
             .addType(
                 TypeSpec
                     .interfaceBuilder(componentClassName)
                     .addOriginatingKSFile(factory.requireContainingFile())
-                    .addAnnotation(scope.toAnnotationSpec())
                     .addOriginAnnotation(factory)
                     .addAnnotation(Subcomponent::class)
                     .addSuperinterface(factory.toClassName())

--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesSubcomponentProcessor.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesSubcomponentProcessor.kt
@@ -13,7 +13,6 @@ import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
-import com.squareup.kotlinpoet.ksp.toAnnotationSpec
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.writeTo
@@ -23,6 +22,7 @@ import software.amazon.lastmile.kotlin.inject.anvil.ContextAware
 import software.amazon.lastmile.kotlin.inject.anvil.ContributesSubcomponent
 import software.amazon.lastmile.kotlin.inject.anvil.LOOKUP_PACKAGE
 import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
+import software.amazon.lastmile.kotlin.inject.anvil.MergeScope
 import software.amazon.lastmile.kotlin.inject.anvil.addOriginAnnotation
 import software.amazon.lastmile.kotlin.inject.anvil.internal.Subcomponent
 
@@ -118,7 +118,15 @@ internal class ContributesSubcomponentProcessor(
         factoryInterface: KSClassDeclaration,
         generatedFactoryInterface: KSClassDeclaration,
     ): ClassName {
-        val scope = subcomponent.scope()
+        val scope = requireNotNull(
+            value = subcomponent.annotations
+                .firstOrNull { isScopeAnnotation(it) }
+                ?.let { MergeScope(this, it) },
+            symbol = subcomponent,
+        ) {
+            "A scope like @SingleIn(Abc::class) is missing."
+        }
+
         val function = factoryInterface.factoryFunctions().single()
 
         val parameters = function.parameters.map {
@@ -135,7 +143,21 @@ internal class ContributesSubcomponentProcessor(
                 TypeSpec
                     .classBuilder(finalComponentClassName)
                     .addAnnotation(Component::class)
-                    .addAnnotation(MergeComponent::class)
+                    .apply {
+                        val scopeOnSubcomponentAnnotation = subcomponent.scope()
+                        if (scopeOnSubcomponentAnnotation.markerFqName != null) {
+                            addAnnotation(
+                                AnnotationSpec.builder(MergeComponent::class)
+                                    .addMember(
+                                        "scope = %T::class",
+                                        ClassName.bestGuess(scopeOnSubcomponentAnnotation.fqName),
+                                    )
+                                    .build(),
+                            )
+                        } else {
+                            addAnnotation(MergeComponent::class)
+                        }
+                    }
                     .addAnnotation(scope.toAnnotationSpec())
                     .addOriginAnnotation(subcomponent)
                     .addModifiers(KModifier.ABSTRACT)

--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesToProcessor.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesToProcessor.kt
@@ -10,7 +10,6 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
-import com.squareup.kotlinpoet.ksp.toAnnotationSpec
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.writeTo
 import software.amazon.lastmile.kotlin.inject.anvil.ContextAware
@@ -35,7 +34,6 @@ import software.amazon.lastmile.kotlin.inject.anvil.addOriginAnnotation
  * ```
  * package $LOOKUP_PACKAGE
  *
- * @SingleInAppScope
  * @Origin(ComponentInterface::class)
  * interface SoftwareAmazonTestComponentInterface : ComponentInterface
  * ```
@@ -51,6 +49,7 @@ internal class ContributesToProcessor(
             .onEach {
                 checkIsInterface(it)
                 checkIsPublic(it)
+                checkHasScope(it)
             }
             .forEach {
                 generateComponentInterface(it)
@@ -61,14 +60,12 @@ internal class ContributesToProcessor(
 
     private fun generateComponentInterface(clazz: KSClassDeclaration) {
         val componentClassName = ClassName(LOOKUP_PACKAGE, clazz.safeClassName)
-        val scope = clazz.scope()
 
         val fileSpec = FileSpec.builder(componentClassName)
             .addType(
                 TypeSpec
                     .interfaceBuilder(componentClassName)
                     .addOriginatingKSFile(clazz.requireContainingFile())
-                    .addAnnotation(scope.toAnnotationSpec())
                     .addOriginAnnotation(clazz)
                     .addSuperinterface(clazz.toClassName())
                     .build(),

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/MergeScopeParserTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/MergeScopeParserTest.kt
@@ -1,0 +1,381 @@
+@file:OptIn(ExperimentalCompilerApi::class)
+
+package software.amazon.lastmile.kotlin.inject.anvil
+
+import assertk.Assert
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.prop
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
+import org.intellij.lang.annotations.Language
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.jupiter.api.Test
+
+class MergeScopeParserTest {
+
+    @Test
+    fun `the scope can be parsed from a scope annotation with zero args`() {
+        compileInPlace(
+            """
+            package software.amazon.test
+    
+            import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
+            import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
+
+            @ContributesTo
+            @SingleInAppScope
+            interface ComponentInterface
+
+            @ContributesBinding
+            @SingleInAppScope
+            interface Binding : CharSequence
+            """,
+        ) { resolver ->
+            assertThat(resolver.clazz("software.amazon.test.ComponentInterface").scope()).isEqualTo(
+                fqName = "software.amazon.test.SingleInAppScope",
+                annotationFqName = "software.amazon.test.SingleInAppScope",
+                markerFqName = null,
+            )
+            assertThat(resolver.clazz("software.amazon.test.Binding").scope()).isEqualTo(
+                fqName = "software.amazon.test.SingleInAppScope",
+                annotationFqName = "software.amazon.test.SingleInAppScope",
+                markerFqName = null,
+            )
+        }
+    }
+
+    @Test
+    fun `the scope can be parsed from a @ContributesBinding annotation`() {
+        compileInPlace(
+            """
+            package software.amazon.test
+    
+            import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
+
+            @ContributesBinding(scope = SingleInAppScope::class)
+            interface Binding : CharSequence
+            """,
+        ) { resolver ->
+            assertThat(resolver.clazz("software.amazon.test.Binding").scope()).isEqualTo(
+                fqName = "software.amazon.test.SingleInAppScope",
+                annotationFqName = "software.amazon.test.SingleInAppScope",
+                markerFqName = null,
+            )
+        }
+    }
+
+    @Test
+    fun `the scope can be parsed from a @ContributesTo annotation`() {
+        compileInPlace(
+            """
+            package software.amazon.test
+    
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+            import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
+
+            @ContributesTo(AppScope::class)
+            interface ComponentInterface1
+
+            @ContributesTo(SingleInAppScope::class)
+            interface ComponentInterface2
+            """,
+        ) { resolver ->
+            assertThat(
+                resolver.clazz("software.amazon.test.ComponentInterface1").scope(),
+            ).isEqualTo(
+                fqName = "software.amazon.lastmile.kotlin.inject.anvil.AppScope",
+                annotationFqName = null,
+                markerFqName = "software.amazon.lastmile.kotlin.inject.anvil.AppScope",
+            )
+            assertThat(
+                resolver.clazz("software.amazon.test.ComponentInterface2").scope(),
+            ).isEqualTo(
+                fqName = "software.amazon.test.SingleInAppScope",
+                annotationFqName = "software.amazon.test.SingleInAppScope",
+                markerFqName = null,
+            )
+        }
+    }
+
+    @Test
+    fun `the scope can be parsed from a @ContributesSubcomponent annotation`() {
+        compileInPlace(
+            """
+            package software.amazon.test
+    
+            import me.tatarka.inject.annotations.Scope
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+            import software.amazon.lastmile.kotlin.inject.anvil.ContributesSubcomponent
+            
+            @Scope
+            annotation class ChildScope
+
+            @ContributesSubcomponent(AppScope::class)
+            interface SubcomponentInterface1 {
+                @ContributesSubcomponent.Factory(String::class)
+                interface Factory {
+                    fun createSubcomponentInterface(): SubcomponentInterface1
+                }          
+            }
+
+            @ContributesSubcomponent
+            @SingleInAppScope
+            interface SubcomponentInterface2 {
+                @ContributesSubcomponent.Factory
+                @ChildScope
+                interface Factory {
+                    fun createSubcomponentInterface(): SubcomponentInterface2
+                }          
+            }
+            """,
+        ) { resolver ->
+            assertThat(
+                resolver.clazz("software.amazon.test.SubcomponentInterface1").scope(),
+            ).isEqualTo(
+                fqName = "software.amazon.lastmile.kotlin.inject.anvil.AppScope",
+                annotationFqName = null,
+                markerFqName = "software.amazon.lastmile.kotlin.inject.anvil.AppScope",
+            )
+            assertThat(
+                resolver.clazz("software.amazon.test.SubcomponentInterface1.Factory").scope(),
+            ).isEqualTo(
+                fqName = "kotlin.String",
+                annotationFqName = null,
+                markerFqName = "kotlin.String",
+            )
+
+            assertThat(
+                resolver.clazz("software.amazon.test.SubcomponentInterface2").scope(),
+            ).isEqualTo(
+                fqName = "software.amazon.test.SingleInAppScope",
+                annotationFqName = "software.amazon.test.SingleInAppScope",
+                markerFqName = null,
+            )
+            assertThat(
+                resolver.clazz("software.amazon.test.SubcomponentInterface2.Factory").scope(),
+            ).isEqualTo(
+                fqName = "software.amazon.test.ChildScope",
+                annotationFqName = "software.amazon.test.ChildScope",
+                markerFqName = null,
+            )
+        }
+    }
+
+    @Test
+    fun `the scope can be parsed from a @MergeComponent annotation`() {
+        compileInPlace(
+            """
+            package software.amazon.test
+                            
+            import me.tatarka.inject.annotations.Component
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+            import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
+
+            @Component
+            @MergeComponent(AppScope::class)
+            abstract class ComponentInterface1 : ComponentInterface1Merged
+
+            @Component
+            @MergeComponent(AppScope::class)
+            @SingleIn(AppScope::class)
+            abstract class ComponentInterface2 : ComponentInterface2Merged
+            """,
+        ) { resolver ->
+            assertThat(
+                resolver.clazz("software.amazon.test.ComponentInterface1").scope(),
+            ).isEqualTo(
+                fqName = "software.amazon.lastmile.kotlin.inject.anvil.AppScope",
+                annotationFqName = null,
+                markerFqName = "software.amazon.lastmile.kotlin.inject.anvil.AppScope",
+            )
+
+            assertThat(
+                resolver.clazz("software.amazon.test.ComponentInterface2").scope(),
+            ).isEqualTo(
+                fqName = "software.amazon.lastmile.kotlin.inject.anvil.AppScope",
+                annotationFqName = null,
+                markerFqName = "software.amazon.lastmile.kotlin.inject.anvil.AppScope",
+            )
+        }
+    }
+
+    @Test
+    fun `the scope can be parsed from a @ContributesBinding annotation without a parameter name`() {
+        compileInPlace(
+            """
+            package software.amazon.test
+    
+            import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
+
+            @ContributesBinding(SingleInAppScope::class)
+            interface Binding : CharSequence
+            """,
+        ) { resolver ->
+            assertThat(resolver.clazz("software.amazon.test.Binding").scope()).isEqualTo(
+                fqName = "software.amazon.test.SingleInAppScope",
+                annotationFqName = "software.amazon.test.SingleInAppScope",
+                markerFqName = null,
+            )
+        }
+    }
+
+    @Test
+    fun `the scope can be parsed from a scope annotation with a marker`() {
+        compileInPlace(
+            """
+            package software.amazon.test
+    
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+            import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
+            import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
+
+            @ContributesTo
+            @SingleIn(AppScope::class)
+            interface ComponentInterface
+
+            @ContributesBinding
+            @SingleIn(AppScope::class)
+            interface Binding : CharSequence
+            """,
+        ) { resolver ->
+            assertThat(resolver.clazz("software.amazon.test.ComponentInterface").scope()).isEqualTo(
+                fqName = "software.amazon.lastmile.kotlin.inject.anvil.AppScope",
+                annotationFqName = "software.amazon.lastmile.kotlin.inject.anvil.SingleIn",
+                markerFqName = "software.amazon.lastmile.kotlin.inject.anvil.AppScope",
+            )
+
+            assertThat(resolver.clazz("software.amazon.test.Binding").scope()).isEqualTo(
+                fqName = "software.amazon.lastmile.kotlin.inject.anvil.AppScope",
+                annotationFqName = "software.amazon.lastmile.kotlin.inject.anvil.SingleIn",
+                markerFqName = "software.amazon.lastmile.kotlin.inject.anvil.AppScope",
+            )
+        }
+    }
+
+    @Test
+    fun `the scope can be parsed from an annotation without explicit scope annotation`() {
+        compileInPlace(
+            """
+            package software.amazon.test
+    
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+            import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
+
+            @ContributesBinding(AppScope::class)
+            interface Binding1 : CharSequence
+
+            @ContributesBinding(multibinding = true, scope = AppScope::class)
+            interface Binding2 : CharSequence
+            """,
+        ) { resolver ->
+            assertThat(resolver.clazz("software.amazon.test.Binding1").scope()).isEqualTo(
+                fqName = "software.amazon.lastmile.kotlin.inject.anvil.AppScope",
+                annotationFqName = null,
+                markerFqName = "software.amazon.lastmile.kotlin.inject.anvil.AppScope",
+            )
+            assertThat(resolver.clazz("software.amazon.test.Binding2").scope()).isEqualTo(
+                fqName = "software.amazon.lastmile.kotlin.inject.anvil.AppScope",
+                annotationFqName = null,
+                markerFqName = "software.amazon.lastmile.kotlin.inject.anvil.AppScope",
+            )
+        }
+    }
+
+    @Test
+    fun `the marker scope is used and a different actual scope can be used for kotlin-inject`() {
+        compileInPlace(
+            """
+            package software.amazon.test
+    
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+            import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
+
+            @ContributesBinding(AppScope::class)
+            @SingleInAppScope
+            interface Binding : CharSequence
+            """,
+        ) { resolver ->
+            assertThat(resolver.clazz("software.amazon.test.Binding").scope()).isEqualTo(
+                fqName = "software.amazon.lastmile.kotlin.inject.anvil.AppScope",
+                annotationFqName = null,
+                markerFqName = "software.amazon.lastmile.kotlin.inject.anvil.AppScope",
+            )
+        }
+    }
+
+    @Test
+    fun `the marker scope is used and a different actual scope can be used for kotlin-inject with a different marker`() {
+        compileInPlace(
+            """
+            package software.amazon.test
+    
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+            import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
+
+            @ContributesBinding(AppScope::class)
+            @SingleIn(String::class)
+            interface Binding : CharSequence
+            """,
+        ) { resolver ->
+            assertThat(resolver.clazz("software.amazon.test.Binding").scope()).isEqualTo(
+                fqName = "software.amazon.lastmile.kotlin.inject.anvil.AppScope",
+                annotationFqName = null,
+                markerFqName = "software.amazon.lastmile.kotlin.inject.anvil.AppScope",
+            )
+        }
+    }
+
+    private fun symbolProcessorProvider(
+        block: ContextAware.(Resolver) -> Unit,
+    ): SymbolProcessorProvider = object : SymbolProcessorProvider {
+        override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+            return object : SymbolProcessor, ContextAware {
+                override fun process(resolver: Resolver): List<KSAnnotated> {
+                    block(this, resolver)
+                    return emptyList()
+                }
+
+                override val logger: KSPLogger = environment.logger
+            }
+        }
+    }
+
+    private fun compileInPlace(
+        @Language("kotlin") vararg sources: String,
+        block: ContextAware.(Resolver) -> Unit,
+    ) {
+        Compilation()
+            .configureKotlinInjectAnvilProcessor(
+                symbolProcessorProviders = setOf(symbolProcessorProvider(block)),
+            )
+            .compile(*sources) {
+                assertThat(exitCode).isEqualTo(OK)
+            }
+    }
+
+    private fun Resolver.clazz(name: String) = requireNotNull(getClassDeclarationByName(name))
+
+    private fun Assert<MergeScope>.isEqualTo(
+        fqName: String,
+        annotationFqName: String?,
+        markerFqName: String?,
+    ) {
+        all {
+            prop(MergeScope::fqName).isEqualTo(fqName)
+            prop(MergeScope::annotationFqName).isEqualTo(annotationFqName)
+            prop(MergeScope::markerFqName).isEqualTo(markerFqName)
+        }
+    }
+}

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesBindingProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesBindingProcessorTest.kt
@@ -20,7 +20,6 @@ import software.amazon.lastmile.kotlin.inject.anvil.isAnnotatedWith
 import software.amazon.lastmile.kotlin.inject.anvil.isNotAnnotatedWith
 import software.amazon.lastmile.kotlin.inject.anvil.origin
 import software.amazon.lastmile.kotlin.inject.anvil.otherScopeSource
-import software.amazon.test.SingleInAppScope
 
 class ContributesBindingProcessorTest {
 
@@ -44,7 +43,6 @@ class ContributesBindingProcessorTest {
             val generatedComponent = impl.generatedComponent
 
             assertThat(generatedComponent.packageName).isEqualTo(LOOKUP_PACKAGE)
-            assertThat(generatedComponent).isAnnotatedWith(SingleInAppScope::class)
             assertThat(generatedComponent.origin).isEqualTo(impl)
 
             val method = generatedComponent.declaredMethods.single()
@@ -77,7 +75,6 @@ class ContributesBindingProcessorTest {
             val generatedComponent = impl.inner.generatedComponent
 
             assertThat(generatedComponent.packageName).isEqualTo(LOOKUP_PACKAGE)
-            assertThat(generatedComponent).isAnnotatedWith(SingleInAppScope::class)
             assertThat(generatedComponent.origin).isEqualTo(impl.inner)
 
             val method = generatedComponent.declaredMethods.single()
@@ -185,63 +182,7 @@ class ContributesBindingProcessorTest {
             val generatedComponent = impl.generatedComponent
 
             assertThat(generatedComponent.packageName).isEqualTo(LOOKUP_PACKAGE)
-            assertThat(generatedComponent).isAnnotatedWith(SingleInAppScope::class)
             assertThat(generatedComponent.origin).isEqualTo(impl)
-        }
-    }
-
-    @Test
-    fun `it's an error to set the scope explicitly when the class is scoped`() {
-        compile(
-            """
-            package software.amazon.test
-    
-            import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
-            import me.tatarka.inject.annotations.Inject
-
-            interface Base
-            
-            @Inject
-            @SingleInAppScope
-            @ContributesBinding(scope = SingleInAppScope::class)
-            class Impl : Base 
-            """,
-            exitCode = COMPILATION_ERROR,
-        ) {
-            assertThat(messages).contains(
-                "A scope was defined explicitly on the @ContributesBinding annotation " +
-                    "`software.amazon.test.SingleInAppScope` and the class itself is scoped " +
-                    "using `software.amazon.test.SingleInAppScope`. In this case the explicit " +
-                    "scope on the @ContributesBinding annotation can be removed.",
-            )
-        }
-    }
-
-    @Test
-    fun `it's an error to set the scope explicitly when the class is scoped - different scopes`() {
-        compile(
-            """
-            package software.amazon.test
-    
-            import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
-            import me.tatarka.inject.annotations.Inject
-
-            interface Base
-
-            @Inject
-            @OtherScope
-            @ContributesBinding(scope = SingleInAppScope::class)
-            class Impl : Base 
-            """,
-            otherScopeSource,
-            exitCode = COMPILATION_ERROR,
-        ) {
-            assertThat(messages).contains(
-                "A scope was defined explicitly on the @ContributesBinding annotation " +
-                    "`software.amazon.test.SingleInAppScope` and the class itself is scoped " +
-                    "using `software.amazon.test.OtherScope`. It's not allowed to mix different " +
-                    "scopes.",
-            )
         }
     }
 
@@ -264,7 +205,7 @@ class ContributesBindingProcessorTest {
         ) {
             assertThat(messages).contains(
                 "Couldn't find scope for Impl. For unscoped objects it is required " +
-                    "to specify the target scope on the @ContributesBinding annotation.",
+                    "to specify the target scope on the annotation.",
             )
         }
     }
@@ -291,7 +232,6 @@ class ContributesBindingProcessorTest {
             val generatedComponent = impl.generatedComponent
 
             assertThat(generatedComponent.packageName).isEqualTo(LOOKUP_PACKAGE)
-            assertThat(generatedComponent).isAnnotatedWith(SingleInAppScope::class)
             assertThat(generatedComponent.origin).isEqualTo(impl)
 
             with(generatedComponent.declaredMethods.single { it.name == "provideImplBase" }) {
@@ -329,7 +269,7 @@ class ContributesBindingProcessorTest {
             exitCode = COMPILATION_ERROR,
         ) {
             assertThat(messages).contains(
-                "All explicit scopes on @ContributesBinding annotations must be the same.",
+                "All explicit scopes on annotations must be the same.",
             )
         }
     }
@@ -356,7 +296,7 @@ class ContributesBindingProcessorTest {
             exitCode = COMPILATION_ERROR,
         ) {
             assertThat(messages).contains(
-                "If one @ContributesBinding annotation has an explicit scope, " +
+                "If one annotation has an explicit scope, " +
                     "then all annotations must specify an explicit scope.",
             )
         }
@@ -408,7 +348,6 @@ class ContributesBindingProcessorTest {
             val generatedComponent = impl.generatedComponent
 
             assertThat(generatedComponent.packageName).isEqualTo(LOOKUP_PACKAGE)
-            assertThat(generatedComponent).isAnnotatedWith(SingleInAppScope::class)
             assertThat(generatedComponent.origin).isEqualTo(impl)
 
             val method = generatedComponent.declaredMethods.single()
@@ -441,7 +380,6 @@ class ContributesBindingProcessorTest {
             val generatedComponent = impl.generatedComponent
 
             assertThat(generatedComponent.packageName).isEqualTo(LOOKUP_PACKAGE)
-            assertThat(generatedComponent).isAnnotatedWith(SingleInAppScope::class)
             assertThat(generatedComponent.origin).isEqualTo(impl)
 
             assertThat(generatedComponent.declaredMethods).hasSize(2)

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesToProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesToProcessorTest.kt
@@ -14,9 +14,7 @@ import software.amazon.lastmile.kotlin.inject.anvil.compile
 import software.amazon.lastmile.kotlin.inject.anvil.componentInterface
 import software.amazon.lastmile.kotlin.inject.anvil.generatedComponent
 import software.amazon.lastmile.kotlin.inject.anvil.inner
-import software.amazon.lastmile.kotlin.inject.anvil.isAnnotatedWith
 import software.amazon.lastmile.kotlin.inject.anvil.origin
-import software.amazon.test.SingleInAppScope
 
 class ContributesToProcessorTest {
 
@@ -37,7 +35,28 @@ class ContributesToProcessorTest {
 
             assertThat(generatedComponent.packageName).isEqualTo(LOOKUP_PACKAGE)
             assertThat(generatedComponent.interfaces).containsExactly(componentInterface)
-            assertThat(generatedComponent).isAnnotatedWith(SingleInAppScope::class)
+            assertThat(generatedComponent.origin).isEqualTo(componentInterface)
+        }
+    }
+
+    @Test
+    fun `a component interface is generated in the lookup package for a contributed component interface using a scope marker`() {
+        compile(
+            """
+            package software.amazon.test
+    
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+            import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
+
+            @ContributesTo(AppScope::class)
+            interface ComponentInterface
+            """,
+        ) {
+            val generatedComponent = componentInterface.generatedComponent
+
+            assertThat(generatedComponent.packageName).isEqualTo(LOOKUP_PACKAGE)
+            assertThat(generatedComponent.interfaces).containsExactly(componentInterface)
             assertThat(generatedComponent.origin).isEqualTo(componentInterface)
         }
     }
@@ -61,7 +80,6 @@ class ContributesToProcessorTest {
 
             assertThat(generatedComponent.packageName).isEqualTo(LOOKUP_PACKAGE)
             assertThat(generatedComponent.interfaces).containsExactly(componentInterface.inner)
-            assertThat(generatedComponent).isAnnotatedWith(SingleInAppScope::class)
             assertThat(generatedComponent.origin).isEqualTo(componentInterface.inner)
         }
     }
@@ -115,7 +133,10 @@ class ContributesToProcessorTest {
             """,
             exitCode = COMPILATION_ERROR,
         ) {
-            assertThat(messages).contains("Couldn't find scope annotation for ComponentInterface.")
+            assertThat(messages).contains(
+                "Couldn't find scope for ComponentInterface. For unscoped " +
+                    "objects it is required to specify the target scope on the annotation.",
+            )
         }
     }
 }

--- a/runtime/api/android/runtime.api
+++ b/runtime/api/android/runtime.api
@@ -9,16 +9,20 @@ public abstract interface annotation class software/amazon/lastmile/kotlin/injec
 }
 
 public abstract interface annotation class software/amazon/lastmile/kotlin/inject/anvil/ContributesSubcomponent : java/lang/annotation/Annotation {
+	public abstract fun scope ()Ljava/lang/Class;
 }
 
 public abstract interface annotation class software/amazon/lastmile/kotlin/inject/anvil/ContributesSubcomponent$Factory : java/lang/annotation/Annotation {
+	public abstract fun scope ()Ljava/lang/Class;
 }
 
 public abstract interface annotation class software/amazon/lastmile/kotlin/inject/anvil/ContributesTo : java/lang/annotation/Annotation {
+	public abstract fun scope ()Ljava/lang/Class;
 }
 
 public abstract interface annotation class software/amazon/lastmile/kotlin/inject/anvil/MergeComponent : java/lang/annotation/Annotation {
 	public abstract fun exclude ()[Ljava/lang/Class;
+	public abstract fun scope ()Ljava/lang/Class;
 }
 
 public abstract interface annotation class software/amazon/lastmile/kotlin/inject/anvil/extend/ContributingAnnotation : java/lang/annotation/Annotation {

--- a/runtime/api/jvm/runtime.api
+++ b/runtime/api/jvm/runtime.api
@@ -9,16 +9,20 @@ public abstract interface annotation class software/amazon/lastmile/kotlin/injec
 }
 
 public abstract interface annotation class software/amazon/lastmile/kotlin/inject/anvil/ContributesSubcomponent : java/lang/annotation/Annotation {
+	public abstract fun scope ()Ljava/lang/Class;
 }
 
 public abstract interface annotation class software/amazon/lastmile/kotlin/inject/anvil/ContributesSubcomponent$Factory : java/lang/annotation/Annotation {
+	public abstract fun scope ()Ljava/lang/Class;
 }
 
 public abstract interface annotation class software/amazon/lastmile/kotlin/inject/anvil/ContributesTo : java/lang/annotation/Annotation {
+	public abstract fun scope ()Ljava/lang/Class;
 }
 
 public abstract interface annotation class software/amazon/lastmile/kotlin/inject/anvil/MergeComponent : java/lang/annotation/Annotation {
 	public abstract fun exclude ()[Ljava/lang/Class;
+	public abstract fun scope ()Ljava/lang/Class;
 }
 
 public abstract interface annotation class software/amazon/lastmile/kotlin/inject/anvil/extend/ContributingAnnotation : java/lang/annotation/Annotation {

--- a/runtime/api/runtime.klib.api
+++ b/runtime/api/runtime.klib.api
@@ -22,31 +22,42 @@ open annotation class software.amazon.lastmile.kotlin.inject.anvil.internal/Subc
 }
 
 open annotation class software.amazon.lastmile.kotlin.inject.anvil/ContributesBinding : kotlin/Annotation { // software.amazon.lastmile.kotlin.inject.anvil/ContributesBinding|null[0]
-    constructor <init>(kotlin.reflect/KClass<out kotlin/Annotation> =..., kotlin.reflect/KClass<*> =..., kotlin/Boolean =...) // software.amazon.lastmile.kotlin.inject.anvil/ContributesBinding.<init>|<init>(kotlin.reflect.KClass<out|kotlin.Annotation>;kotlin.reflect.KClass<*>;kotlin.Boolean){}[0]
+    constructor <init>(kotlin.reflect/KClass<*> =..., kotlin.reflect/KClass<*> =..., kotlin/Boolean =...) // software.amazon.lastmile.kotlin.inject.anvil/ContributesBinding.<init>|<init>(kotlin.reflect.KClass<*>;kotlin.reflect.KClass<*>;kotlin.Boolean){}[0]
 
     final val boundType // software.amazon.lastmile.kotlin.inject.anvil/ContributesBinding.boundType|{}boundType[0]
         final fun <get-boundType>(): kotlin.reflect/KClass<*> // software.amazon.lastmile.kotlin.inject.anvil/ContributesBinding.boundType.<get-boundType>|<get-boundType>(){}[0]
     final val multibinding // software.amazon.lastmile.kotlin.inject.anvil/ContributesBinding.multibinding|{}multibinding[0]
         final fun <get-multibinding>(): kotlin/Boolean // software.amazon.lastmile.kotlin.inject.anvil/ContributesBinding.multibinding.<get-multibinding>|<get-multibinding>(){}[0]
     final val scope // software.amazon.lastmile.kotlin.inject.anvil/ContributesBinding.scope|{}scope[0]
-        final fun <get-scope>(): kotlin.reflect/KClass<out kotlin/Annotation> // software.amazon.lastmile.kotlin.inject.anvil/ContributesBinding.scope.<get-scope>|<get-scope>(){}[0]
+        final fun <get-scope>(): kotlin.reflect/KClass<*> // software.amazon.lastmile.kotlin.inject.anvil/ContributesBinding.scope.<get-scope>|<get-scope>(){}[0]
 }
 
 open annotation class software.amazon.lastmile.kotlin.inject.anvil/ContributesSubcomponent : kotlin/Annotation { // software.amazon.lastmile.kotlin.inject.anvil/ContributesSubcomponent|null[0]
-    constructor <init>() // software.amazon.lastmile.kotlin.inject.anvil/ContributesSubcomponent.<init>|<init>(){}[0]
+    constructor <init>(kotlin.reflect/KClass<*> =...) // software.amazon.lastmile.kotlin.inject.anvil/ContributesSubcomponent.<init>|<init>(kotlin.reflect.KClass<*>){}[0]
+
+    final val scope // software.amazon.lastmile.kotlin.inject.anvil/ContributesSubcomponent.scope|{}scope[0]
+        final fun <get-scope>(): kotlin.reflect/KClass<*> // software.amazon.lastmile.kotlin.inject.anvil/ContributesSubcomponent.scope.<get-scope>|<get-scope>(){}[0]
 
     open annotation class Factory : kotlin/Annotation { // software.amazon.lastmile.kotlin.inject.anvil/ContributesSubcomponent.Factory|null[0]
-        constructor <init>() // software.amazon.lastmile.kotlin.inject.anvil/ContributesSubcomponent.Factory.<init>|<init>(){}[0]
+        constructor <init>(kotlin.reflect/KClass<*> =...) // software.amazon.lastmile.kotlin.inject.anvil/ContributesSubcomponent.Factory.<init>|<init>(kotlin.reflect.KClass<*>){}[0]
+
+        final val scope // software.amazon.lastmile.kotlin.inject.anvil/ContributesSubcomponent.Factory.scope|{}scope[0]
+            final fun <get-scope>(): kotlin.reflect/KClass<*> // software.amazon.lastmile.kotlin.inject.anvil/ContributesSubcomponent.Factory.scope.<get-scope>|<get-scope>(){}[0]
     }
 }
 
 open annotation class software.amazon.lastmile.kotlin.inject.anvil/ContributesTo : kotlin/Annotation { // software.amazon.lastmile.kotlin.inject.anvil/ContributesTo|null[0]
-    constructor <init>() // software.amazon.lastmile.kotlin.inject.anvil/ContributesTo.<init>|<init>(){}[0]
+    constructor <init>(kotlin.reflect/KClass<*> =...) // software.amazon.lastmile.kotlin.inject.anvil/ContributesTo.<init>|<init>(kotlin.reflect.KClass<*>){}[0]
+
+    final val scope // software.amazon.lastmile.kotlin.inject.anvil/ContributesTo.scope|{}scope[0]
+        final fun <get-scope>(): kotlin.reflect/KClass<*> // software.amazon.lastmile.kotlin.inject.anvil/ContributesTo.scope.<get-scope>|<get-scope>(){}[0]
 }
 
 open annotation class software.amazon.lastmile.kotlin.inject.anvil/MergeComponent : kotlin/Annotation { // software.amazon.lastmile.kotlin.inject.anvil/MergeComponent|null[0]
-    constructor <init>(kotlin/Array<kotlin.reflect/KClass<*>> =...) // software.amazon.lastmile.kotlin.inject.anvil/MergeComponent.<init>|<init>(kotlin.Array<kotlin.reflect.KClass<*>>){}[0]
+    constructor <init>(kotlin.reflect/KClass<*> =..., kotlin/Array<kotlin.reflect/KClass<*>> =...) // software.amazon.lastmile.kotlin.inject.anvil/MergeComponent.<init>|<init>(kotlin.reflect.KClass<*>;kotlin.Array<kotlin.reflect.KClass<*>>){}[0]
 
     final val exclude // software.amazon.lastmile.kotlin.inject.anvil/MergeComponent.exclude|{}exclude[0]
         final fun <get-exclude>(): kotlin/Array<kotlin.reflect/KClass<*>> // software.amazon.lastmile.kotlin.inject.anvil/MergeComponent.exclude.<get-exclude>|<get-exclude>(){}[0]
+    final val scope // software.amazon.lastmile.kotlin.inject.anvil/MergeComponent.scope|{}scope[0]
+        final fun <get-scope>(): kotlin.reflect/KClass<*> // software.amazon.lastmile.kotlin.inject.anvil/MergeComponent.scope.<get-scope>|<get-scope>(){}[0]
 }

--- a/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesBinding.kt
+++ b/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesBinding.kt
@@ -82,7 +82,7 @@ public annotation class ContributesBinding(
     /**
      * The scope in which to include this contributed binding.
      */
-    val scope: KClass<out Annotation> = Annotation::class,
+    val scope: KClass<*> = Unit::class,
     /**
      * The type that this class is bound to. When injecting [boundType] the concrete class will be
      * this annotated class.

--- a/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesSubcomponent.kt
+++ b/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesSubcomponent.kt
@@ -1,6 +1,7 @@
 package software.amazon.lastmile.kotlin.inject.anvil
 
 import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.reflect.KClass
 
 /**
  * Generates a subcomponent when the parent component interface is merged.
@@ -102,7 +103,12 @@ import kotlin.annotation.AnnotationTarget.CLASS
  * ```
  */
 @Target(CLASS)
-public annotation class ContributesSubcomponent {
+public annotation class ContributesSubcomponent(
+    /**
+     * The scope in which to include this contributed component interface.
+     */
+    val scope: KClass<*> = Unit::class,
+) {
     /**
      * A factory for the contributed subcomponent.
      *
@@ -112,5 +118,10 @@ public annotation class ContributesSubcomponent {
      * The factory interface must have a single function with the contributed subcomponent as
      * return type. Parameters are supported as mentioned in [ContributesSubcomponent].
      */
-    public annotation class Factory
+    public annotation class Factory(
+        /**
+         * The scope in which to include this contributed component interface.
+         */
+        val scope: KClass<*> = Unit::class,
+    )
 }

--- a/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesTo.kt
+++ b/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesTo.kt
@@ -1,12 +1,18 @@
 package software.amazon.lastmile.kotlin.inject.anvil
 
 import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.reflect.KClass
 
 /**
  * Marks a component interface to be included in the dependency graph in the given `scope`.
  * The processor will automatically add the interface as super type to the final component
  * marked with [MergeComponent].
+ * ```
+ * @ContributesTo(AppScope::class)
+ * interface ComponentInterface { .. }
+ * ```
  *
+ * Or another example where the scope on the component interface is used.
  * ```
  * @ContributesTo
  * @SingleInAppScope
@@ -14,4 +20,9 @@ import kotlin.annotation.AnnotationTarget.CLASS
  * ```
  */
 @Target(CLASS)
-public annotation class ContributesTo
+public annotation class ContributesTo(
+    /**
+     * The scope in which to include this contributed component interface.
+     */
+    val scope: KClass<*> = Unit::class,
+)

--- a/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/MergeComponent.kt
+++ b/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/MergeComponent.kt
@@ -34,6 +34,11 @@ import kotlin.reflect.KClass
 @Target(CLASS)
 public annotation class MergeComponent(
     /**
+     * The scope in which to include this contributed component interface.
+     */
+    val scope: KClass<*> = Unit::class,
+
+    /**
      * List of component interfaces that are contributed to the same scope, but should be
      * excluded from the component.
      */


### PR DESCRIPTION
That's a significant change and changes the API surface. kotlin-inject supports scopes with and without parameters. This change implements a similar API as Anvil for Dagger 2 used to provide, where scope references can be added to annotations, e.g.
```kotlin
@ContributesTo(AppScope::class)
interface ContributedComponentInterface

@Component
@MergeComponent(AppScope::class)
interface MergedComponent
```

The existing mechanism by annotating classes with the scope annotation is still working:
```kotlin
@ContributesTo
@SingleInAppScope
interface ContributedComponentInterface

@Component
@MergeComponent
@SingleInAppScope
interface MergedComponent
```

Most of the logic changed in the way we resolve the scope where to merge code, which happens during compilation.

There is an additional change for generated code, where we no longer add the scope to generated interfaces and instead rely on the `@Origin` annotation to determine the scope. That simplifies code generation and is backwards compatible.

Resolves #1.