### PR TITLE
Update documentation to account for new annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@
 
 ### Added
 
-- Added a default scope annotation `@SingleIn`.
+- Added new artifact `:runtime-optional`, which provides access to `@SingleIn`, `@ForScope` and `AppScope`, see #16.
+- Added support for scopes with parameters, e.g. to support `@SingleIn(AppScope::class)` and `@ContributesTo(AppScope::class)`, see #1.
 - Allow specifying custom contributing annotations via KSP option instead of using `@ContributingAnnotation`.
 
 ### Changed
+
+- Updated the documentation and decided to recommend scope references as parameter to contribute and merge types. In other words: we prefer using the `@SingleIn(SomeScope::class)` annotation and explicitly declaring the scope on the `@Contribute*(SomeScope::class)` annotations. Support for the old way may go away, see #36.
 
 ### Deprecated
 
@@ -18,8 +21,6 @@
 ### Fixed
 
 ### Security
-
-### Custom Code Generator
 
 ### Other Notes & Contributions
 

--- a/README.md
+++ b/README.md
@@ -11,22 +11,21 @@ project provides a similar feature set for the `kotlin-inject` framework.
 The extensions provided by `kotlin-inject-anvil` allow you to contribute and automatically merge
 component interfaces without explicit references in code.
 ```kotlin
-@ContributesTo
-@SingleInAppScope
+@ContributesTo(AppScope::class)
 interface AppIdComponent {
     @Provides
     fun provideAppId(): String = "demo app"
 }
 
 @Inject
-@SingleInAppScope
-@ContributesBinding
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
 class RealAuthenticator : Authenticator
 
 // The final kotlin-inject component.
 @Component
-@MergeComponent
-@SingleInAppScope
+@MergeComponent(AppScope::class)
+@SingleIn(AppScope::class)
 interface AppComponent : AppComponentMerged
 ```
 The generated code will ensure that `AppIdComponent` is a super type of `AppComponent` and the
@@ -42,7 +41,9 @@ dependencies {
     kspCommonMainMetadata "software.amazon.lastmile.kotlin.inject.anvil:compiler:$version"
     commonMainImplementation "software.amazon.lastmile.kotlin.inject.anvil:runtime:$version"
 
-    // Optional module for scope and qualifier annotations.
+    // Optional module, but strongly suggested to import. It contains the
+    // @SingleIn scope and @ForScope qualifier annotation together with the
+    // AppScope::class marker.
     commonMainImplementation "software.amazon.lastmile.kotlin.inject.anvil:runtime-optional:$version"
 }
 ```
@@ -67,15 +68,14 @@ maven {
 
 Component interfaces can be contributed using the `@ContributesTo` annotation:
 ```kotlin
-@ContributesTo
-@SingleInAppScope
+@ContributesTo(AppScope::class)
 interface AppIdComponent {
     @Provides
     fun provideAppId(): String = "demo app"
 }
 ```
-In order to know in which component the contributed interface should be merged, the scope
-annotation `@SingleInAppScope` must be added to the component interface.
+The scope `AppScope::class` tells `kotlin-inject-anvil` in which component to merge this
+interface.
 
 #### `@ContributesBinding`
 
@@ -92,11 +92,10 @@ Whenever you inject `Authenticator` the expectation is to receive an instance of
 method:
 ```kotlin
 @Inject
-@SingleInAppScope
+@SingleIn(AppScope::class)
 class RealAuthenticator : Authenticator
 
-@ContributesTo
-@SingleInAppScope
+@ContributesTo(AppScope::class)
 interface AuthenticatorComponent {
     @Provides
     fun provideAuthenticator(authenticator: RealAuthenticator): Authenticator = authenticator
@@ -107,8 +106,8 @@ Note that `@ContributesTo` is leveraged to automatically add the interface to th
 However, this is still too much code and can be simplified further with `@ContributesBinding`:
 ```kotlin
 @Inject
-@SingleInAppScope
-@ContributesBinding
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
 class RealAuthenticator : Authenticator
 ```
 `@ContributesBinding` will generate a provider method similar to the one above and automatically
@@ -120,13 +119,13 @@ add it to the final component.
 
 ```kotlin
 @Inject
-@SingleInAppScope
-@ContributesBinding(multibinding = true)
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, multibinding = true)
 class LoggingInterceptor : Interceptor
 
 @Component
-@MergeComponent
-@SingleInAppScope
+@MergeComponent(AppScope::class)
+@SingleIn(AppScope::class)
 abstract class AppComponent {
     // Will be contributed to this set multi-binding.
     abstract val interceptors: Set<Interceptor>
@@ -138,12 +137,11 @@ abstract class AppComponent {
 The `@ContributesSubcomponent` annotation allows you to define a subcomponent in any Gradle module,
 but the final `@Component` will be generated when the parent component is merged.
 ```kotlin
-@ContributesSubcomponent
-@SingleInRendererScope
+@ContributesSubcomponent(LoggedInScope::class)
+@SingleIn(LoggedInScope::class)
 interface RendererComponent {
 
-    @ContributesSubcomponent.Factory
-    @SingleInAppScope
+    @ContributesSubcomponent.Factory(AppScope::class)
     interface Factory {
         fun createRendererComponent(): RendererComponent
     }
@@ -158,22 +156,22 @@ With `kotlin-inject` components are defined similar to the one below in order to
 object graph at runtime:
 ```kotlin
 @Component
-@SingleInAppScope
+@SingleIn(AppScope::class)
 interface AppComponent
 ```
 In order to pick up all contributions, you must add the `@MergeComponent` annotation:
 ```kotlin
 @Component
-@MergeComponent
-@SingleInAppScope
+@MergeComponent(AppScope::class)
+@SingleIn(AppScope::class)
 interface AppComponent
 ```
 This will generate a new interface `AppComponentMerged` in the same package as `AppComponent`.
 This generated interface must be added as super type:
 ```kotlin
 @Component
-@MergeComponent
-@SingleInAppScope
+@MergeComponent(AppScope::class)
+@SingleIn(AppScope::class)
 interface AppComponent : AppComponentMerged
 ```
 With this setup any contribution is automatically merged. These steps have to be repeated for
@@ -183,13 +181,57 @@ every component in your project.
 
 The plugin builds a connection between contributions and merged components through the scope.
 How scopes function with `kotlin-inject` is described in the
-[documentation](https://github.com/evant/kotlin-inject#scopes). The same scope annotations are
-reused for this plugin. E.g. a scope may be defined as:
+[documentation](https://github.com/evant/kotlin-inject#scopes).
+
+`kotlin-inject` supports scopes with and without parameters. For `kotlin-inject-anvil` we decided
+to prefer scope references as parameter to contribute and merge types as the
+[`@SingleIn` annotation](runtime-optional/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/SingleIn.kt)
+defines it:
+```kotlin
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealAuthenticator : Authenticator
+
+@Component
+@MergeComponent(AppScope::class)
+@SingleIn(AppScope::class)
+interface AppComponent : AppComponentMerged
+```
+The `@SingleIn` annotation needs to be explicitly imported!
+```groovy
+dependencies {
+    commonMainImplementation "software.amazon.lastmile.kotlin.inject.anvil:runtime-optional:$version"
+}
+```
+
+However, scopes without parameters are also supported, such as:
 ```kotlin
 import me.tatarka.inject.annotations.Scope
 
 @Scope
-annotation class SingleInAppScope
+annotation class Singleton
+```
+Instead of using the `scope` parameter on the `@Contributes*` annotations, you'd add this
+annotation on the class itself and `kotlin-anvil-inject` will still build the correct
+connections and merge the code:
+```kotlin
+@ContributesTo
+@Singleton
+interface AppIdComponent {
+    @Provides
+    fun provideAppId(): String = "demo app"
+}
+
+@Inject
+@Singleton
+@ContributesBinding
+class RealAuthenticator : Authenticator
+
+@Component
+@MergeComponent
+@Singleton
+interface AppComponent : AppComponentMerged
 ```
 
 ## Sample
@@ -217,29 +259,35 @@ annotation class MyCustomAnnotation
 
 Your custom KSP symbol processor uses this annotation as trigger and generates following code:
 ```kotlin
-@ContributesTo
-@SingleInAppScope
+@ContributesTo(AppScope::class)
 interface MyCustomComponent {
     @Provides
     fun provideMyCustomType(): MyCustomType = ...
 }
 ```
 This generated component interface `MyCustomComponent` will be picked up by `kotlin-inject-anvil's`
-symbol processors and contributed to the `@SingleInAppScope` due to the `@ContributesTo`
-annotation.
+symbol processors and contributed to the `AppScope` due to the `@ContributesTo` annotation.
 
 **Custom annotations and symbol processors are very powerful and allow you to adjust
 `kotlin-inject-anvil` to your needs and your codebase.**
 
-There are two ways to indicate these to `kotlin-inject-anvil`. This is important for incremental compilation and multi-round support.
+There are two ways to indicate these to `kotlin-inject-anvil`. This is important for incremental
+compilation and multi-round support.
 
-1. Annotate your annotation with the `@ContributingAnnotation` marker and run `kotlin-inject-anvil`'s compiler over the project the annotation is hosted in. This ensures the annotation is understood as a contributing annotation in all downstream usages of this annotation.
+1. **This is the preferred option**: Annotate your annotation with the `@ContributingAnnotation`
+    marker and run `kotlin-inject-anvil`'s compiler over the project the annotation is hosted in.
+    Adding the compiler as described in the [the setup](#setup) is important, otherwise the
+    `@ContributingAnnotation` has no effect. With this the annotation is understood as a
+    contributing annotation in all downstream usages of this annotation.
     ```kotlin
     @ContributingAnnotation // <--- add this!
     @Target(CLASS)
     annotation class MyCustomAnnotation
     ```
-2. Alternatively, if you don't control the annotation or otherwise cannot use option 1, you can specify custom annotations via the `kotlin-inject-anvil-contributing-annotations` KSP option. This option value is a colon-delimited string whose values are the canonical class names of your custom annotations.
+2. Alternatively, if you don't control the annotation or otherwise cannot use option 1, you can
+    specify custom annotations via the `kotlin-inject-anvil-contributing-annotations` KSP option.
+    This option value is a colon-delimited string whose values are the canonical class names of
+    your custom annotations.
     ```kotlin
     ksp {
       arg("kotlin-inject-anvil-contributing-annotations", "com.example.MyCustomAnnotation")

--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/MergeScope.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/MergeScope.kt
@@ -22,12 +22,12 @@ import com.squareup.kotlinpoet.ksp.toClassName
  * Or the old way:
  * ```
  * @ContributesTo
- * @SingleInAppScope
+ * @Singleton
  * interface ContributedComponentInterface
  *
  * @Component
  * @MergeComponent
- * @SingleInAppScope
+ * @Singleton
  * interface MergedComponent
  * ```
  */
@@ -36,7 +36,7 @@ internal sealed class MergeScope {
      * The fully qualified name of the annotation used as scope, e.g.
      * ```
      * @ContributesTo
-     * @SingleInAppScope
+     * @Singleton
      * interface Abc
      * ```
      * Note that the annotation itself is annotated with `@Scope`.
@@ -50,7 +50,7 @@ internal sealed class MergeScope {
      * If the `scope` parameter is used and the argument is annotated with `@Scope`, then
      * this value is non-null, e.g. for this:
      * ```
-     * @ContributesBinding(scope = SingleInAppScope::class)
+     * @ContributesBinding(scope = Singleton::class)
      * class Binding : SuperType
      * ```
      */
@@ -66,14 +66,14 @@ internal sealed class MergeScope {
      * The value is null, if no marker is used, e.g.
      * ```
      * @ContributesTo
-     * @SingleInAppScope
+     * @Singleton
      * interface Abc
      * ```
      *
      * The value is also null, when the `scope` parameter is used and the argument is annotated
      * with `@Scope`, e.g.
      * ```
-     * @ContributesBinding(scope = SingleInAppScope::class)
+     * @ContributesBinding(scope = Singleton::class)
      * class Binding : SuperType
      * ```
      */

--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesBindingProcessor.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesBindingProcessor.kt
@@ -37,7 +37,7 @@ import kotlin.reflect.KClass
  * package software.amazon.test
  *
  * @Inject
- * @SingleInAppScope
+ * @SingleIn(AppScope::class)
  * @ContributesBinding
  * class RealAuthenticator : Authenticator
  * ```
@@ -45,7 +45,7 @@ import kotlin.reflect.KClass
  * ```
  * package $LOOKUP_PACKAGE
  *
- * @Origin(ComponentInterface::class)
+ * @Origin(RealAuthenticator::class)
  * interface SoftwareAmazonTestRealAuthenticator {
  *     @Provides fun provideRealAuthenticatorAuthenticator(
  *         realAuthenticator: RealAuthenticator

--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesSubcomponentFactoryProcessor.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesSubcomponentFactoryProcessor.kt
@@ -31,11 +31,10 @@ import software.amazon.lastmile.kotlin.inject.anvil.internal.Subcomponent
  * ```
  * package software.amazon.test
  *
- * @ContributesSubcomponent
- * @ChildScope
+ * @ContributesSubcomponent(LoggedInScope::class)
+ * @SingleIn(AppScope::class)
  * interface Subcomponent {
- *     @ContributesSubcomponent.Factory
- *     @ParentScope
+ *     @ContributesSubcomponent.Factory(AppScope::class)
  *     interface Factory {
  *         fun createSubcomponent(): Subcomponent
  *     }

--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesSubcomponentProcessor.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesSubcomponentProcessor.kt
@@ -40,11 +40,10 @@ import software.amazon.lastmile.kotlin.inject.anvil.internal.Subcomponent
  * ```
  * package software.amazon.test
  *
- * @ContributesSubcomponent
- * @ChildScope
+ * @ContributesSubcomponent(LoggedInScope::class)
+ * @SingleIn(AppScope::class)
  * interface Subcomponent {
- *     @ContributesSubcomponent.Factory
- *     @ParentScope
+ *     @ContributesSubcomponent.Factory(AppScope::class)
  *     interface Factory {
  *         fun createSubcomponent(): Subcomponent
  *     }
@@ -52,8 +51,8 @@ import software.amazon.lastmile.kotlin.inject.anvil.internal.Subcomponent
  *
  * // The trigger for generating the code:
  * @Component
- * @MergeComponent
- * @ParentScope
+ * @MergeComponent(AppScope::class)
+ * @SingleIn(AppScope::class)
  * abstract class ParentComponent : ParentComponentMerged
  * ```
  * Will generate:
@@ -61,8 +60,8 @@ import software.amazon.lastmile.kotlin.inject.anvil.internal.Subcomponent
  * package software.amazon.test
  *
  * @Component
- * @MergeComponent
- * @ChildScope
+ * @MergeComponent(LoggedInScope::class)
+ * @SingleIn(AppScope::class)
  * abstract class SubcomponentFinal(
  *     @Component val parentComponent: ParentComponent,
  * ) : Subcomponent, SubcomponentMerged {

--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesToProcessor.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesToProcessor.kt
@@ -26,8 +26,8 @@ import software.amazon.lastmile.kotlin.inject.anvil.addOriginAnnotation
  * ```
  * package software.amazon.test
  *
- * @ContributesTo
- * @SingleInAppScope
+ * @ContributesTo(AppScope::class)
+ * @SingleIn(AppScope::class)
  * interface ComponentInterface
  * ```
  * Will generate:

--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/MergeComponentProcessor.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/MergeComponentProcessor.kt
@@ -40,15 +40,14 @@ import software.amazon.lastmile.kotlin.inject.anvil.requireQualifiedName
  * package software.amazon.test
  *
  * @Component
- * @MergeComponent
- * @SingleInAppScope
+ * @MergeComponent(AppScope::class)
+ * @SingleIn(AppScope::class)
  * abstract class TestComponent : TestComponentMerged
  * ```
  * Will generate:
  * ```
  * package software.amazon.test
  *
- * @SingleInAppScope
  * interface TestComponentMerged : MergedSuperTypes
  * ```
  */

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/KotlinInjectExtensionSymbolProcessorProviderTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/KotlinInjectExtensionSymbolProcessorProviderTest.kt
@@ -28,7 +28,7 @@ class KotlinInjectExtensionSymbolProcessorProviderTest {
                 import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
     
                 @ContributesTo
-                @SingleInAppScope
+                @Singleton
                 interface ComponentInterface
                 """,
             )

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/MergeScopeParserTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/MergeScopeParserTest.kt
@@ -31,22 +31,22 @@ class MergeScopeParserTest {
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
 
             @ContributesTo
-            @SingleInAppScope
+            @Singleton
             interface ComponentInterface
 
             @ContributesBinding
-            @SingleInAppScope
+            @Singleton
             interface Binding : CharSequence
             """,
         ) { resolver ->
             assertThat(resolver.clazz("software.amazon.test.ComponentInterface").scope()).isEqualTo(
-                fqName = "software.amazon.test.SingleInAppScope",
-                annotationFqName = "software.amazon.test.SingleInAppScope",
+                fqName = "software.amazon.test.Singleton",
+                annotationFqName = "software.amazon.test.Singleton",
                 markerFqName = null,
             )
             assertThat(resolver.clazz("software.amazon.test.Binding").scope()).isEqualTo(
-                fqName = "software.amazon.test.SingleInAppScope",
-                annotationFqName = "software.amazon.test.SingleInAppScope",
+                fqName = "software.amazon.test.Singleton",
+                annotationFqName = "software.amazon.test.Singleton",
                 markerFqName = null,
             )
         }
@@ -60,13 +60,13 @@ class MergeScopeParserTest {
     
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
 
-            @ContributesBinding(scope = SingleInAppScope::class)
+            @ContributesBinding(scope = Singleton::class)
             interface Binding : CharSequence
             """,
         ) { resolver ->
             assertThat(resolver.clazz("software.amazon.test.Binding").scope()).isEqualTo(
-                fqName = "software.amazon.test.SingleInAppScope",
-                annotationFqName = "software.amazon.test.SingleInAppScope",
+                fqName = "software.amazon.test.Singleton",
+                annotationFqName = "software.amazon.test.Singleton",
                 markerFqName = null,
             )
         }
@@ -84,7 +84,7 @@ class MergeScopeParserTest {
             @ContributesTo(AppScope::class)
             interface ComponentInterface1
 
-            @ContributesTo(SingleInAppScope::class)
+            @ContributesTo(Singleton::class)
             interface ComponentInterface2
             """,
         ) { resolver ->
@@ -98,8 +98,8 @@ class MergeScopeParserTest {
             assertThat(
                 resolver.clazz("software.amazon.test.ComponentInterface2").scope(),
             ).isEqualTo(
-                fqName = "software.amazon.test.SingleInAppScope",
-                annotationFqName = "software.amazon.test.SingleInAppScope",
+                fqName = "software.amazon.test.Singleton",
+                annotationFqName = "software.amazon.test.Singleton",
                 markerFqName = null,
             )
         }
@@ -127,7 +127,7 @@ class MergeScopeParserTest {
             }
 
             @ContributesSubcomponent
-            @SingleInAppScope
+            @Singleton
             interface SubcomponentInterface2 {
                 @ContributesSubcomponent.Factory
                 @ChildScope
@@ -155,8 +155,8 @@ class MergeScopeParserTest {
             assertThat(
                 resolver.clazz("software.amazon.test.SubcomponentInterface2").scope(),
             ).isEqualTo(
-                fqName = "software.amazon.test.SingleInAppScope",
-                annotationFqName = "software.amazon.test.SingleInAppScope",
+                fqName = "software.amazon.test.Singleton",
+                annotationFqName = "software.amazon.test.Singleton",
                 markerFqName = null,
             )
             assertThat(
@@ -216,13 +216,13 @@ class MergeScopeParserTest {
     
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
 
-            @ContributesBinding(SingleInAppScope::class)
+            @ContributesBinding(Singleton::class)
             interface Binding : CharSequence
             """,
         ) { resolver ->
             assertThat(resolver.clazz("software.amazon.test.Binding").scope()).isEqualTo(
-                fqName = "software.amazon.test.SingleInAppScope",
-                annotationFqName = "software.amazon.test.SingleInAppScope",
+                fqName = "software.amazon.test.Singleton",
+                annotationFqName = "software.amazon.test.Singleton",
                 markerFqName = null,
             )
         }
@@ -302,7 +302,7 @@ class MergeScopeParserTest {
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
 
             @ContributesBinding(AppScope::class)
-            @SingleInAppScope
+            @Singleton
             interface Binding : CharSequence
             """,
         ) { resolver ->

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesBindingProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesBindingProcessorTest.kt
@@ -35,7 +35,7 @@ class ContributesBindingProcessorTest {
             interface Base
 
             @Inject
-            @SingleInAppScope
+            @Singleton
             @ContributesBinding
             class Impl : Base 
             """,
@@ -66,7 +66,7 @@ class ContributesBindingProcessorTest {
 
             interface Impl {
                 @Inject
-                @SingleInAppScope
+                @Singleton
                 @ContributesBinding
                 class Inner : Base
             } 
@@ -98,12 +98,12 @@ class ContributesBindingProcessorTest {
             interface Base2 : Base
 
             @Inject
-            @SingleInAppScope
+            @Singleton
             @ContributesBinding(boundType = Base::class)
             class Impl : Base2 
 
             @Inject
-            @SingleInAppScope
+            @Singleton
             @ContributesBinding
             class Impl2 : Base2 
             """,
@@ -125,7 +125,7 @@ class ContributesBindingProcessorTest {
             import me.tatarka.inject.annotations.Inject
 
             @Inject
-            @SingleInAppScope
+            @Singleton
             @ContributesBinding
             class Impl 
             """,
@@ -150,7 +150,7 @@ class ContributesBindingProcessorTest {
             interface Base2
 
             @Inject
-            @SingleInAppScope
+            @Singleton
             @ContributesBinding
             class Impl : Base, Base2
             """,
@@ -175,7 +175,7 @@ class ContributesBindingProcessorTest {
             interface Base
 
             @Inject
-            @ContributesBinding(scope = SingleInAppScope::class)
+            @ContributesBinding(scope = Singleton::class)
             class Impl : Base 
             """,
         ) {
@@ -223,7 +223,7 @@ class ContributesBindingProcessorTest {
             interface Base2
 
             @Inject
-            @SingleInAppScope
+            @Singleton
             @ContributesBinding(boundType = Base::class)
             @ContributesBinding(boundType = Base2::class)
             class Impl : Base, Base2 
@@ -261,7 +261,7 @@ class ContributesBindingProcessorTest {
             interface Base2
 
             @Inject
-            @ContributesBinding(scope = SingleInAppScope::class, boundType = Base::class)
+            @ContributesBinding(scope = Singleton::class, boundType = Base::class)
             @ContributesBinding(scope = OtherScope::class, boundType = Base2::class)
             class Impl : Base, Base2 
             """,
@@ -288,7 +288,7 @@ class ContributesBindingProcessorTest {
 
             @Inject
             @OtherScope
-            @ContributesBinding(scope = SingleInAppScope::class, boundType = Base::class)
+            @ContributesBinding(scope = Singleton::class, boundType = Base::class)
             @ContributesBinding(boundType = Base2::class)
             class Impl : Base, Base2 
             """,
@@ -315,7 +315,7 @@ class ContributesBindingProcessorTest {
             interface Base
 
             @Inject
-            @SingleInAppScope
+            @Singleton
             @ContributesBinding(boundType = Base::class)
             @ContributesBinding(boundType = Base::class)
             class Impl : Base, Base2 
@@ -340,7 +340,7 @@ class ContributesBindingProcessorTest {
             interface Base
 
             @Inject
-            @SingleInAppScope
+            @Singleton
             @ContributesBinding(multibinding = true)
             class Impl : Base 
             """,
@@ -371,7 +371,7 @@ class ContributesBindingProcessorTest {
             interface Base
 
             @Inject
-            @SingleInAppScope
+            @Singleton
             @ContributesBinding(multibinding = false)
             @ContributesBinding(multibinding = true)
             class Impl : Base 

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesToProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesToProcessorTest.kt
@@ -27,7 +27,7 @@ class ContributesToProcessorTest {
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
 
             @ContributesTo
-            @SingleInAppScope
+            @Singleton
             interface ComponentInterface
             """,
         ) {
@@ -71,7 +71,7 @@ class ContributesToProcessorTest {
 
             interface ComponentInterface {
                 @ContributesTo
-                @SingleInAppScope
+                @Singleton
                 interface Inner
             }
             """,
@@ -93,7 +93,7 @@ class ContributesToProcessorTest {
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
 
             @ContributesTo
-            @SingleInAppScope
+            @Singleton
             private interface ComponentInterface
             """,
             exitCode = COMPILATION_ERROR,
@@ -111,7 +111,7 @@ class ContributesToProcessorTest {
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
 
             @ContributesTo
-            @SingleInAppScope
+            @Singleton
             abstract class ComponentInterface
             """,
             exitCode = COMPILATION_ERROR,

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/MergeComponentProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/MergeComponentProcessorTest.kt
@@ -476,13 +476,13 @@ class MergeComponentProcessorTest {
             interface Base
 
             @Inject
-            @SingleInAppScope
+            @Singleton
             @ContributesBinding
             class Impl : Base
 
             @Component
             @MergeComponent(exclude = [Impl::class])
-            @SingleInAppScope
+            @Singleton
             abstract class ComponentInterface : ComponentInterfaceMerged {
                 abstract val base: Base
             }

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/extend/CustomSymbolProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/extend/CustomSymbolProcessorTest.kt
@@ -28,7 +28,7 @@ import software.amazon.lastmile.kotlin.inject.anvil.OPTION_CONTRIBUTING_ANNOTATI
 import software.amazon.lastmile.kotlin.inject.anvil.compile
 import software.amazon.lastmile.kotlin.inject.anvil.componentInterface
 import software.amazon.lastmile.kotlin.inject.anvil.mergedComponent
-import software.amazon.test.SingleInAppScope
+import software.amazon.test.Singleton
 
 private const val CONTRIBUTING_ANNOTATION =
     "software.amazon.lastmile.kotlin.inject.anvil.extend.ContributingAnnotation"
@@ -75,7 +75,7 @@ class CustomSymbolProcessorTest {
     
                 @Component
                 @MergeComponent
-                @SingleInAppScope
+                @Singleton
                 interface ComponentInterface : ComponentInterfaceMerged {
                     val string: String
                 }
@@ -138,7 +138,7 @@ class CustomSymbolProcessorTest {
     
                 @Component
                 @MergeComponent
-                @SingleInAppScope
+                @Singleton
                 interface ComponentInterface : ComponentInterfaceMerged {
                     val string: String
                 }
@@ -168,7 +168,7 @@ class CustomSymbolProcessorTest {
                                         .interfaceBuilder(componentClassName)
                                         .addOriginatingKSFile(clazz.containingFile!!)
                                         .addAnnotation(ContributesTo::class)
-                                        .addAnnotation(SingleInAppScope::class)
+                                        .addAnnotation(Singleton::class)
                                         .addFunction(
                                             FunSpec
                                                 .builder("provideString")

--- a/compiler/src/test/kotlin/software/amazon/test/Singleton.kt
+++ b/compiler/src/test/kotlin/software/amazon/test/Singleton.kt
@@ -4,4 +4,4 @@ import me.tatarka.inject.annotations.Scope
 
 @Scope
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER)
-annotation class SingleInAppScope
+annotation class Singleton

--- a/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesBinding.kt
+++ b/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesBinding.kt
@@ -10,11 +10,10 @@ import kotlin.reflect.KClass
  * interface Authenticator
  *
  * @Inject
- * @SingleInAppScope
+ * @SingleIn(AppScope::class)
  * class RealAuthenticator : Authenticator {
  *
- *     @ContributesTo
- *     @SingleInAppScope
+ *     @ContributesTo(AppScope::class)
  *     interface Component {
  *         @Provides fun provideAuthenticator(authenticator: RealAuthenticator): Authenticator =
  *             authenticator
@@ -29,38 +28,28 @@ import kotlin.reflect.KClass
  * interface Authenticator
  *
  * @Inject
- * @SingleInAppScope
- * @ContributesBinding
+ * @SingleIn(AppScope::class)
+ * @ContributesBinding(AppScope::class)
  * class RealAuthenticator : Authenticator
  * ```
  * Notice that it's optional to specify [boundType], if there is only exactly one super type. If
  * there are multiple super types, then it's required to specify the parameter:
  * ```
  * @Inject
- * @SingleInAppScope
+ * @SingleIn(AppScope::class)
  * @ContributesBinding(
+ *     scope = AppScope::class,
  *     boundType = Authenticator::class,
  * )
  * class RealAuthenticator : AbstractTokenProvider(), Authenticator
  * ```
  *
- * The generated component interface will automatically be associated with the scope of the
- * contributed binding. If the class is unscoped (not a singleton), then the target scope must be
- * specified in the `@ContributesTo` annotation:
- * ```
- * @Inject
- * @ContributesBinding(
- *     scope = SingleInAppScope::class,
- * )
- * class CounterPresenterImpl : CounterPresenter
- * ```
- *
  * This annotation is repeatable and a binding can be generated for multiple types:
  * ```
  * @Inject
- * @SingleInAppScope
- * @ContributesBinding(boundType = Authenticator::class)
- * @ContributesBinding(boundType = AbstractTokenProvider::class)
+ * @SingleIn(AppScope::class)
+ * @ContributesBinding(AppScope::class, boundType = Authenticator::class)
+ * @ContributesBinding(AppScope::class, boundType = AbstractTokenProvider::class)
  * class RealAuthenticator : AbstractTokenProvider(), Authenticator
  * ```
  *
@@ -71,9 +60,22 @@ import kotlin.reflect.KClass
  *
  * ```
  * @Inject
- * @ContributesBinding(boundType = Base::class)
- * @ContributesBinding(boundType = Base2::class, multibinding = true)
+ * @ContributesBinding(AppScope::class, boundType = Base::class)
+ * @ContributesBinding(AppScope::class, boundType = Base2::class, multibinding = true)
  * class Impl : Base, Base2
+ * ```
+ *
+ * ## Custom scopes
+ *
+ * If you use your own scope annotations without the references such as `AppScope::class`, then
+ * you can use your scope directly on the class:
+ * ```
+ * interface Authenticator
+ *
+ * @Inject
+ * @Singleton
+ * @ContributesBinding
+ * class RealAuthenticator : Authenticator
  * ```
  */
 @Target(CLASS)

--- a/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesTo.kt
+++ b/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesTo.kt
@@ -4,7 +4,7 @@ import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.reflect.KClass
 
 /**
- * Marks a component interface to be included in the dependency graph in the given `scope`.
+ * Marks a component interface to be included in the dependency graph in the given [scope].
  * The processor will automatically add the interface as super type to the final component
  * marked with [MergeComponent].
  * ```
@@ -12,10 +12,14 @@ import kotlin.reflect.KClass
  * interface ComponentInterface { .. }
  * ```
  *
- * Or another example where the scope on the component interface is used.
+ *
+ * ## Custom scopes
+ *
+ * If you use your own scope annotations without the references such as `AppScope::class`, then
+ * you can use your scope directly on the class:
  * ```
  * @ContributesTo
- * @SingleInAppScope
+ * @Singleton
  * interface ComponentInterface { .. }
  * ```
  */

--- a/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/MergeComponent.kt
+++ b/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/MergeComponent.kt
@@ -9,8 +9,8 @@ import kotlin.reflect.KClass
  *
  * ```
  * @Component
- * @MergeComponent
- * @SingleInAppScope
+ * @MergeComponent(AppScope::class)
+ * @SingleIn(AppScope::class)
  * abstract class AppComponent(
  *     ...
  * ) : AppComponentMerged
@@ -23,12 +23,27 @@ import kotlin.reflect.KClass
  *
  * ```
  * @MergeComponent(
+ *     scope = AppScope::class,
  *     exclude = [
  *       ComponentInterface::class,
  *       Other.Component::class,
  *     ]
  * )
  * interface AppComponent
+ * ```
+ *
+ *
+ * ## Custom scopes
+ *
+ * If you use your own scope annotations without the references such as `AppScope::class`, then
+ * you can use your scope directly on the class:
+ * ```
+ * @Component
+ * @MergeComponent
+ * @Singleton
+ * abstract class AppComponent(
+ *     ...
+ * ) : AppComponentMerged
  * ```
  */
 @Target(CLASS)


### PR DESCRIPTION
Update the documentation prefer the `@SingleIn` annotation over the old approach due to its convenience and flexibility. This also aligns the API better with the original Anvil implementation.

Resolves #1, #16