### PR TITLE
Enforce scope parameter on all `@Contributes*` annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+* **BREAKING CHANGE:** Enforce scope parameter on all `@Contributes*` annotations and stop using the kotlin-inject scope implicitly, see #36.
+
 ### Deprecated
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -179,59 +179,37 @@ every component in your project.
 
 ### Scopes
 
-The plugin builds a connection between contributions and merged components through the scope.
-How scopes function with `kotlin-inject` is described in the
-[documentation](https://github.com/evant/kotlin-inject#scopes).
+The plugin builds a connection between contributions and merged components through the scope
+parameters. Scope classes are only markers and have no further meaning besides building a
+connection between contributions and merging them. The class `AppScope` from the sample could
+look like this:
+```kotlin
+object AppScope
+```
 
-`kotlin-inject` supports scopes with and without parameters. For `kotlin-inject-anvil` we decided
-to prefer scope references as parameter to contribute and merge types as the
-[`@SingleIn` annotation](runtime-optional/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/SingleIn.kt)
-defines it:
+Scope classes are independent of the `kotlin-inject`
+[scopes](https://github.com/evant/kotlin-inject#scopes). It's still necessary to set a scope for
+the `kotlin-inject` components or to make instances a singleton in a scope, e.g.
 ```kotlin
 @Inject
-@SingleIn(AppScope::class)
+@SingleIn(AppScope::class) // scope for kotlin-inject
 @ContributesBinding(AppScope::class)
 class RealAuthenticator : Authenticator
 
 @Component
 @MergeComponent(AppScope::class)
-@SingleIn(AppScope::class)
-interface AppComponent : AppComponentMerged
+@SingleIn(AppScope::class) // scope for kotlin-inject
+interface AppComponent
 ```
-The `@SingleIn` annotation needs to be explicitly imported!
+
+`kotlin-inject-anvil` provides the
+[`@SingleIn` scope annotation](runtime-optional/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/SingleIn.kt)
+optionally by importing following module. We strongly recommend to use the annotation for
+consistency.
 ```groovy
 dependencies {
     commonMainImplementation "software.amazon.lastmile.kotlin.inject.anvil:runtime-optional:$version"
 }
-```
-
-However, scopes without parameters are also supported, such as:
-```kotlin
-import me.tatarka.inject.annotations.Scope
-
-@Scope
-annotation class Singleton
-```
-Instead of using the `scope` parameter on the `@Contributes*` annotations, you'd add this
-annotation on the class itself and `kotlin-anvil-inject` will still build the correct
-connections and merge the code:
-```kotlin
-@ContributesTo
-@Singleton
-interface AppIdComponent {
-    @Provides
-    fun provideAppId(): String = "demo app"
-}
-
-@Inject
-@Singleton
-@ContributesBinding
-class RealAuthenticator : Authenticator
-
-@Component
-@MergeComponent
-@Singleton
-interface AppComponent : AppComponentMerged
 ```
 
 ## Sample

--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/MergeScope.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/MergeScope.kt
@@ -1,16 +1,10 @@
 package software.amazon.lastmile.kotlin.inject.anvil
 
-import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSType
-import com.squareup.kotlinpoet.AnnotationSpec
-import com.squareup.kotlinpoet.ksp.toAnnotationSpec
-import com.squareup.kotlinpoet.ksp.toClassName
 
 /**
  * Represents the destination of contributed types and which types should be merged during
- * the merge phase. There is complexity to this problem, because `kotlin-inject` didn't
- * support parameters for scopes initially and our Anvil extensions added support for that. Later,
- * we started supporting parameters, which changed the API. E.g. one could use:
+ * the merge phase, e.g.
  * ```
  * @ContributesTo(AppScope::class)
  * interface ContributedComponentInterface
@@ -19,139 +13,8 @@ import com.squareup.kotlinpoet.ksp.toClassName
  * @MergeComponent(AppScope::class)
  * interface MergedComponent
  * ```
- * Or the old way:
- * ```
- * @ContributesTo
- * @Singleton
- * interface ContributedComponentInterface
- *
- * @Component
- * @MergeComponent
- * @Singleton
- * interface MergedComponent
- * ```
+ * Where `AppScope` would represent the "MergeScope".
  */
-internal sealed class MergeScope {
-    /**
-     * The fully qualified name of the annotation used as scope, e.g.
-     * ```
-     * @ContributesTo
-     * @Singleton
-     * interface Abc
-     * ```
-     * Note that the annotation itself is annotated with `@Scope`.
-     *
-     * The value is `null`, when only a marker is used, e.g.
-     * ```
-     * @ContributesTo(AppScope::class)
-     * interface Abc
-     * ```
-     *
-     * If the `scope` parameter is used and the argument is annotated with `@Scope`, then
-     * this value is non-null, e.g. for this:
-     * ```
-     * @ContributesBinding(scope = Singleton::class)
-     * class Binding : SuperType
-     * ```
-     */
-    abstract val annotationFqName: String?
-
-    /**
-     * A marker for a scope that isn't itself annotated with `@Scope`, e.g.
-     * ```
-     * @ContributesTo(AppScope::class)
-     * interface Abc
-     * ```
-     *
-     * The value is null, if no marker is used, e.g.
-     * ```
-     * @ContributesTo
-     * @Singleton
-     * interface Abc
-     * ```
-     *
-     * The value is also null, when the `scope` parameter is used and the argument is annotated
-     * with `@Scope`, e.g.
-     * ```
-     * @ContributesBinding(scope = Singleton::class)
-     * class Binding : SuperType
-     * ```
-     */
-    abstract val markerFqName: String?
-
-    /**
-     * A reference to the scope.
-     *
-     * [markerFqName] is preferred, because it allows us to decouple contributions from
-     * kotlin-inject's scoping mechanism. E.g. imagine someone using `@Singleton` as a scope, and
-     * they'd like to adopt kotlin-inject-anvil with `@ContributesTo(AppScope::class)`. Because we
-     * prefer the marker, this would be supported.
-     */
-    val fqName: String get() = requireNotNull(markerFqName ?: annotationFqName)
-
-    abstract fun toAnnotationSpec(): AnnotationSpec
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is MergeScope) return false
-
-        if (fqName != other.fqName) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        return fqName.hashCode()
-    }
-
-    private class MarkerBasedMergeScope(
-        override val annotationFqName: String,
-        override val markerFqName: String?,
-        private val ksAnnotation: KSAnnotation,
-    ) : MergeScope() {
-        override fun toAnnotationSpec(): AnnotationSpec {
-            return ksAnnotation.toAnnotationSpec()
-        }
-    }
-
-    private class AnnotationBasedMergeScope(
-        override val annotationFqName: String?,
-        override val markerFqName: String?,
-        private val ksType: KSType,
-    ) : MergeScope() {
-        override fun toAnnotationSpec(): AnnotationSpec {
-            return AnnotationSpec.builder(ksType.toClassName()).build()
-        }
-    }
-
-    companion object {
-        operator fun invoke(
-            contextAware: ContextAware,
-            annotationType: KSType?,
-            markerType: KSType?,
-        ): MergeScope {
-            val nonNullType = contextAware.requireNotNull(markerType ?: annotationType, null) {
-                "Couldn't determine scope. No scope annotation nor marker found."
-            }
-
-            return AnnotationBasedMergeScope(
-                annotationFqName = annotationType?.declaration?.requireQualifiedName(contextAware),
-                markerFqName = markerType?.declaration?.requireQualifiedName(contextAware),
-                ksType = nonNullType,
-            )
-        }
-
-        operator fun invoke(
-            contextAware: ContextAware,
-            ksAnnotation: KSAnnotation,
-        ): MergeScope {
-            return MarkerBasedMergeScope(
-                annotationFqName = ksAnnotation.annotationType.resolve().declaration
-                    .requireQualifiedName(contextAware),
-                markerFqName = ksAnnotation.scopeParameter(contextAware)?.declaration
-                    ?.requireQualifiedName(contextAware),
-                ksAnnotation = ksAnnotation,
-            )
-        }
-    }
-}
+internal data class MergeScope(
+    val type: KSType,
+)

--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/Util.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/Util.kt
@@ -4,7 +4,6 @@ import com.google.devtools.ksp.isDefault
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSDeclaration
-import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSValueArgument
 import com.squareup.kotlinpoet.Annotatable
 import com.squareup.kotlinpoet.AnnotationSpec
@@ -73,13 +72,4 @@ internal fun KSDeclaration.requireQualifiedName(contextAware: ContextAware): Str
 
 internal fun KClass<*>.requireQualifiedName(): String = requireNotNull(qualifiedName) {
     "Qualified name was null for $this"
-}
-
-internal fun KSAnnotation.scopeParameter(contextAware: ContextAware): KSType? {
-    return arguments.firstOrNull { it.name?.asString() == "scope" }
-        ?.let { it.value as? KSType }
-        ?.takeIf {
-            it.declaration.requireQualifiedName(contextAware) !=
-                Unit::class.requireQualifiedName()
-        }
 }

--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesBindingProcessor.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesBindingProcessor.kt
@@ -38,7 +38,7 @@ import kotlin.reflect.KClass
  *
  * @Inject
  * @SingleIn(AppScope::class)
- * @ContributesBinding
+ * @ContributesBinding(AppScope::class)
  * class RealAuthenticator : Authenticator
  * ```
  * Will generate:

--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesSubcomponentFactoryProcessor.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesSubcomponentFactoryProcessor.kt
@@ -112,6 +112,8 @@ internal class ContributesSubcomponentFactoryProcessor(
             "Factory interfaces must be inner classes of the contributed subcomponent, which " +
                 "need to be annotated with @ContributesSubcomponent."
         }
+
+        requireKotlinInjectScope(subcomponent)
     }
 
     private fun checkSingleFunction(factory: KSClassDeclaration) {

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/CommonSourceCode.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/CommonSourceCode.kt
@@ -3,7 +3,6 @@
 package software.amazon.lastmile.kotlin.inject.anvil
 
 import com.tschuchort.compiletesting.JvmCompilationResult
-import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import software.amazon.lastmile.kotlin.inject.anvil.internal.Origin
 import java.lang.reflect.Method
@@ -58,16 +57,3 @@ internal val Class<*>.propertyAnnotations: Array<out Annotation>
         .filter { Modifier.isStatic(it.modifiers) }
         .single { it.name.endsWith("\$annotations") }
         .annotations
-
-@Language("kotlin")
-internal val otherScopeSource = """
-    package software.amazon.test
-    
-    import me.tatarka.inject.annotations.Scope
-
-    @Scope
-    annotation class OtherScope
-
-    @Scope
-    annotation class OtherScope2
-"""

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/KotlinInjectExtensionSymbolProcessorProviderTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/KotlinInjectExtensionSymbolProcessorProviderTest.kt
@@ -26,9 +26,10 @@ class KotlinInjectExtensionSymbolProcessorProviderTest {
                 package software.amazon.test
     
                 import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
+                import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
     
-                @ContributesTo
-                @Singleton
+                @ContributesTo(Unit::class)
+                @SingleIn(Unit::class)
                 interface ComponentInterface
                 """,
             )

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesSubcomponentFactoryProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesSubcomponentFactoryProcessorTest.kt
@@ -9,7 +9,6 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import com.tschuchort.compiletesting.JvmCompilationResult
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
-import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.jupiter.api.Test
 import software.amazon.lastmile.kotlin.inject.anvil.LOOKUP_PACKAGE
@@ -26,37 +25,10 @@ class ContributesSubcomponentFactoryProcessorTest {
             package software.amazon.test
     
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesSubcomponent
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 
-            @ContributesSubcomponent
-            @ChildScope
-            interface SubcomponentInterface {
-                @ContributesSubcomponent.Factory
-                @ParentScope
-                interface Factory {
-                    fun createSubcomponentInterface(): SubcomponentInterface
-                }          
-            }
-            """,
-            scopesSource,
-        ) {
-            val generatedComponent = subcomponent.factory.generatedComponent
-
-            assertThat(generatedComponent.packageName).isEqualTo(LOOKUP_PACKAGE)
-            assertThat(generatedComponent.interfaces).containsExactly(subcomponent.factory)
-            assertThat(generatedComponent.origin).isEqualTo(subcomponent.factory)
-        }
-    }
-
-    @Test
-    fun `a component interface is generated in the lookup package for a contributed subcomponent factory using a scope marker`() {
-        compile(
-            """
-            package software.amazon.test
-    
-            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
-            import software.amazon.lastmile.kotlin.inject.anvil.ContributesSubcomponent
-
-            @ContributesSubcomponent(AppScope::class)
+            @ContributesSubcomponent(Unit::class)
+            @SingleIn(Unit::class)
             interface SubcomponentInterface {
                 @ContributesSubcomponent.Factory(String::class)
                 interface Factory {
@@ -64,7 +36,6 @@ class ContributesSubcomponentFactoryProcessorTest {
                 }          
             }
             """,
-            scopesSource,
         ) {
             val generatedComponent = subcomponent.factory.generatedComponent
 
@@ -81,19 +52,18 @@ class ContributesSubcomponentFactoryProcessorTest {
             package software.amazon.test
     
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesSubcomponent
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 
-            @ContributesSubcomponent
-            @ChildScope
+            @ContributesSubcomponent(String::class)
+            @SingleIn(String::class)
             interface SubcomponentInterface {
-                @ContributesSubcomponent.Factory
-                @ParentScope
+                @ContributesSubcomponent.Factory(Unit::class)
                 interface Factory {
                     fun createSubcomponentInterface(): SubcomponentInterface
                     fun createSubcomponentInterface2(): SubcomponentInterface
                 }          
             }
             """,
-            scopesSource,
             exitCode = COMPILATION_ERROR,
         ) {
             assertThat(messages).contains(
@@ -110,12 +80,12 @@ class ContributesSubcomponentFactoryProcessorTest {
             package software.amazon.test
     
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesSubcomponent
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 
-            @ContributesSubcomponent
-            @ChildScope
+            @ContributesSubcomponent(String::class)
+            @SingleIn(String::class)
             interface SubcomponentInterface {
-                @ContributesSubcomponent.Factory
-                @ParentScope
+                @ContributesSubcomponent.Factory(Unit::class)
                 interface Factory {
                     fun createSubcomponentInterface(): SubcomponentInterface
                     fun createSubcomponentInterface2(): SubcomponentInterface = 
@@ -125,7 +95,6 @@ class ContributesSubcomponentFactoryProcessorTest {
                 }          
             }
             """,
-            scopesSource,
         ) {
             assertThat(subcomponent.factory.generatedComponent).isNotNull()
         }
@@ -138,16 +107,15 @@ class ContributesSubcomponentFactoryProcessorTest {
             package software.amazon.test
     
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesSubcomponent
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 
-            @ContributesSubcomponent
-            @ChildScope
+            @ContributesSubcomponent(String::class)
+            @SingleIn(String::class)
             interface SubcomponentInterface {
-                @ContributesSubcomponent.Factory
-                @ParentScope
+                @ContributesSubcomponent.Factory(Unit::class)
                 interface Factory         
             }
             """,
-            scopesSource,
             exitCode = COMPILATION_ERROR,
         ) {
             assertThat(messages).contains(
@@ -164,18 +132,17 @@ class ContributesSubcomponentFactoryProcessorTest {
             package software.amazon.test
     
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesSubcomponent
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 
-            @ContributesSubcomponent
-            @ChildScope
+            @ContributesSubcomponent(String::class)
+            @SingleIn(String::class)
             interface SubcomponentInterface {
-                @ContributesSubcomponent.Factory
-                @ParentScope
+                @ContributesSubcomponent.Factory(Unit::class)
                 interface Factory {
                     fun createSubcomponentInterface(): Any
                 }          
             }
             """,
-            scopesSource,
             exitCode = COMPILATION_ERROR,
         ) {
             assertThat(messages).contains(
@@ -192,18 +159,17 @@ class ContributesSubcomponentFactoryProcessorTest {
             package software.amazon.test
     
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesSubcomponent
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 
-            @ContributesSubcomponent
-            @ChildScope
+            @ContributesSubcomponent(String::class)
+            @SingleIn(String::class)
             interface SubcomponentInterface {
-                @ContributesSubcomponent.Factory
-                @ParentScope
+                @ContributesSubcomponent.Factory(Unit::class)
                 interface Factory {
                     fun createSubcomponentInterface()
                 }          
             }
             """,
-            scopesSource,
             exitCode = COMPILATION_ERROR,
         ) {
             assertThat(messages).contains(
@@ -221,16 +187,13 @@ class ContributesSubcomponentFactoryProcessorTest {
 
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesSubcomponent
     
-            @ChildScope
             interface SubcomponentInterface {
-                @ContributesSubcomponent.Factory
-                @ParentScope
+                @ContributesSubcomponent.Factory(Unit::class)
                 interface Factory {
                     fun createSubcomponentInterface(): SubcomponentInterface
                 }          
             }
             """,
-            scopesSource,
             exitCode = COMPILATION_ERROR,
         ) {
             assertThat(messages).contains(
@@ -248,13 +211,11 @@ class ContributesSubcomponentFactoryProcessorTest {
 
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesSubcomponent
     
-            @ContributesSubcomponent.Factory
-            @ParentScope
+            @ContributesSubcomponent.Factory(String::class)
             interface Factory {
                 fun createSubcomponentInterface(): Factory
             }          
             """,
-            scopesSource,
             exitCode = COMPILATION_ERROR,
         ) {
             assertThat(messages).contains(
@@ -271,16 +232,13 @@ class ContributesSubcomponentFactoryProcessorTest {
     
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesSubcomponent
 
-            @ContributesSubcomponent
-            @ChildScope
+            @ContributesSubcomponent(String::class)
             interface SubcomponentInterface {
-                @ParentScope
                 interface Factory {
                     fun createSubcomponentInterface(): SubcomponentInterface
                 }          
             }
             """,
-            scopesSource,
             exitCode = COMPILATION_ERROR,
         ) {
             assertThat(messages).contains(
@@ -297,23 +255,21 @@ class ContributesSubcomponentFactoryProcessorTest {
             package software.amazon.test
     
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesSubcomponent
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 
-            @ContributesSubcomponent
-            @ChildScope
+            @ContributesSubcomponent(String::class)
+            @SingleIn(String::class)
             interface SubcomponentInterface {
-                @ParentScope
-                @ContributesSubcomponent.Factory
+                @ContributesSubcomponent.Factory(Unit::class)
                 interface Factory1 {
                     fun createSubcomponentInterface1(): SubcomponentInterface
                 }          
-                @ParentScope
-                @ContributesSubcomponent.Factory
+                @ContributesSubcomponent.Factory(Unit::class)
                 interface Factory2 {
                     fun createSubcomponentInterface2(): SubcomponentInterface
                 }          
             }
             """,
-            scopesSource,
             exitCode = COMPILATION_ERROR,
         ) {
             assertThat(messages).contains(
@@ -323,22 +279,33 @@ class ContributesSubcomponentFactoryProcessorTest {
         }
     }
 
+    @Test
+    fun `a contributed subcomponent must have a kotlin-inject scope`() {
+        compile(
+            """
+            package software.amazon.test
+    
+            import software.amazon.lastmile.kotlin.inject.anvil.ContributesSubcomponent
+
+            @ContributesSubcomponent(String::class)
+            interface SubcomponentInterface {
+                @ContributesSubcomponent.Factory(Unit::class)
+                interface Factory {
+                    fun createSubcomponentInterface1(): SubcomponentInterface
+                }          
+            }
+            """,
+            exitCode = COMPILATION_ERROR,
+        ) {
+            assertThat(messages).contains(
+                "A kotlin-inject scope like @SingleIn(Abc::class) is missing.",
+            )
+        }
+    }
+
     private val JvmCompilationResult.subcomponent: Class<*>
         get() = classLoader.loadClass("software.amazon.test.SubcomponentInterface")
 
     private val Class<*>.factory: Class<*>
         get() = classes.single { it.simpleName == "Factory" }
-
-    @Language("kotlin")
-    internal val scopesSource = """
-        package software.amazon.test
-        
-        import me.tatarka.inject.annotations.Scope
-    
-        @Scope
-        annotation class ParentScope
-    
-        @Scope
-        annotation class ChildScope
-    """
 }

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesToProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesToProcessorTest.kt
@@ -26,30 +26,7 @@ class ContributesToProcessorTest {
     
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
 
-            @ContributesTo
-            @Singleton
-            interface ComponentInterface
-            """,
-        ) {
-            val generatedComponent = componentInterface.generatedComponent
-
-            assertThat(generatedComponent.packageName).isEqualTo(LOOKUP_PACKAGE)
-            assertThat(generatedComponent.interfaces).containsExactly(componentInterface)
-            assertThat(generatedComponent.origin).isEqualTo(componentInterface)
-        }
-    }
-
-    @Test
-    fun `a component interface is generated in the lookup package for a contributed component interface using a scope marker`() {
-        compile(
-            """
-            package software.amazon.test
-    
-            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
-            import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
-            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
-
-            @ContributesTo(AppScope::class)
+            @ContributesTo(Unit::class)
             interface ComponentInterface
             """,
         ) {
@@ -70,8 +47,7 @@ class ContributesToProcessorTest {
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
 
             interface ComponentInterface {
-                @ContributesTo
-                @Singleton
+                @ContributesTo(Unit::class)
                 interface Inner
             }
             """,
@@ -92,8 +68,7 @@ class ContributesToProcessorTest {
     
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
 
-            @ContributesTo
-            @Singleton
+            @ContributesTo(Unit::class)
             private interface ComponentInterface
             """,
             exitCode = COMPILATION_ERROR,
@@ -110,33 +85,12 @@ class ContributesToProcessorTest {
     
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
 
-            @ContributesTo
-            @Singleton
+            @ContributesTo(Unit::class)
             abstract class ComponentInterface
             """,
             exitCode = COMPILATION_ERROR,
         ) {
             assertThat(messages).contains("Only interfaces can be contributed.")
-        }
-    }
-
-    @Test
-    fun `a scope must be present`() {
-        compile(
-            """
-            package software.amazon.test
-    
-            import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
-
-            @ContributesTo
-            interface ComponentInterface
-            """,
-            exitCode = COMPILATION_ERROR,
-        ) {
-            assertThat(messages).contains(
-                "Couldn't find scope for ComponentInterface. For unscoped " +
-                    "objects it is required to specify the target scope on the annotation.",
-            )
         }
     }
 }

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/MergeComponentProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/MergeComponentProcessorTest.kt
@@ -16,61 +16,11 @@ import software.amazon.lastmile.kotlin.inject.anvil.compile
 import software.amazon.lastmile.kotlin.inject.anvil.componentInterface
 import software.amazon.lastmile.kotlin.inject.anvil.inner
 import software.amazon.lastmile.kotlin.inject.anvil.mergedComponent
-import software.amazon.lastmile.kotlin.inject.anvil.otherScopeSource
 
 class MergeComponentProcessorTest {
 
     @Test
     fun `component interfaces are merged`() {
-        compile(
-            """
-            package software.amazon.test
-                            
-            import me.tatarka.inject.annotations.Component
-            import me.tatarka.inject.annotations.Inject
-            import me.tatarka.inject.annotations.Provides
-            import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
-            import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
-
-            interface Base
-
-            @Inject
-            @OtherScope
-            class Impl : Base {
-            
-                @ContributesTo
-                @OtherScope
-                interface Component {
-                    @Provides fun provideImpl(impl: Impl): Base = impl
-
-                    val string: String
-                }
-            }
-
-            @ContributesTo
-            @OtherScope
-            interface StringComponent {
-                @Provides fun provideString(): String = "abc"
-            }
-
-            @Component
-            @MergeComponent
-            @OtherScope
-            abstract class ComponentInterface : ComponentInterfaceMerged {
-                abstract val base: Base
-            }
-            """,
-            otherScopeSource,
-        ) {
-            assertThat(componentInterface.mergedComponent).isNotNull()
-
-            assertThat(stringComponent.isAssignableFrom(componentInterface)).isTrue()
-            assertThat(implComponent.isAssignableFrom(componentInterface)).isTrue()
-        }
-    }
-
-    @Test
-    fun `component interfaces are merged using marker scopes`() {
         compile(
             """
             package software.amazon.test
@@ -126,17 +76,18 @@ class MergeComponentProcessorTest {
             import me.tatarka.inject.annotations.Component
             import me.tatarka.inject.annotations.Inject
             import me.tatarka.inject.annotations.Provides
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
             import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 
             interface Base
 
             @Inject
-            @OtherScope
+            @SingleIn(AppScope::class)
             class Impl : Base {
             
-                @ContributesTo
-                @OtherScope
+                @ContributesTo(AppScope::class)
                 interface Component {
                     @Provides fun provideImpl(impl: Impl): Base = impl
 
@@ -144,20 +95,18 @@ class MergeComponentProcessorTest {
                 }
             }
 
-            @ContributesTo
-            @OtherScope
+            @ContributesTo(AppScope::class)
             interface StringComponent {
                 @Provides fun provideString(): String = "abc"
             }
 
             interface ComponentInterface {
                 @Component
-                @MergeComponent
-                @OtherScope
+                @MergeComponent(AppScope::class)
+                @SingleIn(AppScope::class)
                 interface Inner : ComponentInterfaceInnerMerged
             }
             """,
-            otherScopeSource,
         ) {
             assertThat(componentInterface.inner.mergedComponent).isNotNull()
 
@@ -175,46 +124,10 @@ class MergeComponentProcessorTest {
             import me.tatarka.inject.annotations.Component
             import me.tatarka.inject.annotations.Inject
             import me.tatarka.inject.annotations.Provides
-            import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
-            import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
-
-            interface Base
-
-            @Inject
-            @OtherScope
-            @ContributesBinding
-            class Impl : Base
-
-            @Component
-            @MergeComponent
-            @OtherScope
-            abstract class ComponentInterface : ComponentInterfaceMerged {
-                abstract val base: Base
-            }
-            """,
-            otherScopeSource,
-        ) {
-            assertThat(componentInterface.mergedComponent).isNotNull()
-
-            assertThat(
-                classLoader.loadClass("$LOOKUP_PACKAGE.SoftwareAmazonTestImpl")
-                    .isAssignableFrom(componentInterface),
-            ).isTrue()
-        }
-    }
-
-    @Test
-    fun `contributed bindings are merged using marker scopes`() {
-        compile(
-            """
-            package software.amazon.test
-                            
-            import me.tatarka.inject.annotations.Component
-            import me.tatarka.inject.annotations.Inject
-            import me.tatarka.inject.annotations.Provides
             import software.amazon.lastmile.kotlin.inject.anvil.AppScope
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
             import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 
             interface Base
 
@@ -224,6 +137,7 @@ class MergeComponentProcessorTest {
 
             @Component
             @MergeComponent(AppScope::class)
+            @SingleIn(AppScope::class)
             abstract class ComponentInterface : ComponentInterfaceMerged {
                 abstract val base: Base
             }
@@ -246,16 +160,17 @@ class MergeComponentProcessorTest {
                             
             import me.tatarka.inject.annotations.Inject
             import me.tatarka.inject.annotations.Provides
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 
             interface Base
 
             @Inject
-            @OtherScope
+            @SingleIn(AppScope::class)
             class Impl : Base {
             
-                @ContributesTo
-                @OtherScope
+                @ContributesTo(AppScope::class)
                 interface Component {
                     @Provides fun provideImpl(impl: Impl): Base = impl
 
@@ -263,7 +178,6 @@ class MergeComponentProcessorTest {
                 }
             }
             """,
-            otherScopeSource,
         )
 
         compile(
@@ -273,18 +187,19 @@ class MergeComponentProcessorTest {
             import me.tatarka.inject.annotations.Component
             import me.tatarka.inject.annotations.Inject
             import me.tatarka.inject.annotations.Provides
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
             import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 
-            @ContributesTo
-            @OtherScope
+            @ContributesTo(AppScope::class)
             interface StringComponent {
                 @Provides fun provideString(): String = "abc"
             }
 
             @Component
-            @MergeComponent
-            @OtherScope
+            @MergeComponent(AppScope::class)
+            @SingleIn(AppScope::class)
             abstract class ComponentInterface : ComponentInterfaceMerged {
                 abstract val base: Base
             }
@@ -299,28 +214,6 @@ class MergeComponentProcessorTest {
     }
 
     @Test
-    fun `a scope must be present`() {
-        compile(
-            """
-            package software.amazon.test
-                            
-            import me.tatarka.inject.annotations.Component
-            import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
-
-            @Component
-            @MergeComponent
-            abstract class ComponentInterface : ComponentInterfaceMerged
-            """,
-            exitCode = COMPILATION_ERROR,
-        ) {
-            assertThat(messages).contains(
-                "Couldn't find scope for ComponentInterface. For unscoped " +
-                    "objects it is required to specify the target scope on the annotation.",
-            )
-        }
-    }
-
-    @Test
     fun `component interfaces with a different scope are not merged`() {
         compile(
             """
@@ -329,36 +222,35 @@ class MergeComponentProcessorTest {
             import me.tatarka.inject.annotations.Component
             import me.tatarka.inject.annotations.Inject
             import me.tatarka.inject.annotations.Provides
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
             import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 
             interface Base
 
             @Inject
-            @OtherScope
+            @SingleIn(AppScope::class)
             class Impl : Base {
             
-                @ContributesTo
-                @OtherScope
+                @ContributesTo(AppScope::class)
                 interface Component {
                     @Provides fun provideImpl(impl: Impl): Base = impl
                 }
             }
 
-            @ContributesTo
-            @OtherScope2
+            @ContributesTo(Unit::class)
             interface StringComponent {
                 @Provides fun provideString(): String = "abc"
             }
 
             @Component
-            @MergeComponent
-            @OtherScope
+            @MergeComponent(AppScope::class)
+            @SingleIn(AppScope::class)
             abstract class ComponentInterface : ComponentInterfaceMerged {
                 abstract val base: Base
             }
             """,
-            otherScopeSource,
         ) {
             assertThat(componentInterface.mergedComponent).isNotNull()
 
@@ -376,36 +268,35 @@ class MergeComponentProcessorTest {
             import me.tatarka.inject.annotations.Component
             import me.tatarka.inject.annotations.Inject
             import me.tatarka.inject.annotations.Provides
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
             import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 
             interface Base
 
             @Inject
-            @OtherScope
+            @SingleIn(AppScope::class)
             class Impl : Base {
             
-                @ContributesTo
-                @OtherScope
+                @ContributesTo(AppScope::class)
                 interface Component {
                     @Provides fun provideImpl(impl: Impl): Base = impl
                 }
             }
 
-            @ContributesTo
-            @OtherScope
+            @ContributesTo(AppScope::class)
             interface StringComponent {
                 val string: String
             }
 
             @Component
-            @MergeComponent(exclude = [StringComponent::class])
-            @OtherScope
+            @MergeComponent(AppScope::class, exclude = [StringComponent::class])
+            @SingleIn(AppScope::class)
             abstract class ComponentInterface : ComponentInterfaceMerged {
                 abstract val base: Base
             }
             """,
-            otherScopeSource,
         ) {
             assertThat(componentInterface.mergedComponent).isNotNull()
 
@@ -423,36 +314,35 @@ class MergeComponentProcessorTest {
             import me.tatarka.inject.annotations.Component
             import me.tatarka.inject.annotations.Inject
             import me.tatarka.inject.annotations.Provides
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
             import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 
             interface Base
 
             @Inject
-            @OtherScope
+            @SingleIn(AppScope::class)
             class Impl : Base {
             
-                @ContributesTo
-                @OtherScope
+                @ContributesTo(AppScope::class)
                 interface Component {
                     @Provides fun provideImpl(impl: Impl): Base = impl
                 }
             }
 
-            @ContributesTo
-            @OtherScope
+            @ContributesTo(AppScope::class)
             interface StringComponent {
                 val string: String
             }
 
             @Component
-            @MergeComponent(OtherScope::class, [StringComponent::class])
-            @OtherScope
+            @MergeComponent(AppScope::class, [StringComponent::class])
+            @SingleIn(AppScope::class)
             abstract class ComponentInterface : ComponentInterfaceMerged {
                 abstract val base: Base
             }
             """,
-            otherScopeSource,
         ) {
             assertThat(componentInterface.mergedComponent).isNotNull()
 
@@ -470,19 +360,21 @@ class MergeComponentProcessorTest {
             import me.tatarka.inject.annotations.Component
             import me.tatarka.inject.annotations.Inject
             import me.tatarka.inject.annotations.Provides
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
             import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 
             interface Base
 
             @Inject
-            @Singleton
-            @ContributesBinding
+            @SingleIn(AppScope::class)
+            @ContributesBinding(AppScope::class)
             class Impl : Base
 
             @Component
-            @MergeComponent(exclude = [Impl::class])
-            @Singleton
+            @MergeComponent(AppScope::class, exclude = [Impl::class])
+            @SingleIn(AppScope::class)
             abstract class ComponentInterface : ComponentInterfaceMerged {
                 abstract val base: Base
             }
@@ -505,38 +397,39 @@ class MergeComponentProcessorTest {
             import me.tatarka.inject.annotations.Component
             import me.tatarka.inject.annotations.Inject
             import me.tatarka.inject.annotations.Provides
+            import me.tatarka.inject.annotations.Scope
             import software.amazon.lastmile.kotlin.inject.anvil.AppScope
             import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
             import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
 
+            @Scope
+            annotation class Singleton
+
             interface Base
 
             @Inject
-            @OtherScope
+            @Singleton
             class Impl : Base {
             
                 @ContributesTo(AppScope::class)
-                @OtherScope
                 interface Component {
                     @Provides fun provideImpl(impl: Impl): Base = impl
                 }
             }
 
             // Note this is contributed to a different scope.
-            @ContributesTo
-            @OtherScope
+            @ContributesTo(Unit::class)
             interface StringComponent {
                 @Provides fun provideString(): String = "abc"
             }
 
             @Component
             @MergeComponent(AppScope::class)
-            @OtherScope
+            @Singleton
             abstract class ComponentInterface : ComponentInterfaceMerged {
                 abstract val base: Base
             }
             """,
-            otherScopeSource,
         ) {
             assertThat(componentInterface.mergedComponent).isNotNull()
 

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/extend/CustomSymbolProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/extend/CustomSymbolProcessorTest.kt
@@ -11,6 +11,7 @@ import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
@@ -25,10 +26,10 @@ import org.junit.jupiter.params.provider.ValueSource
 import software.amazon.lastmile.kotlin.inject.anvil.Compilation
 import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
 import software.amazon.lastmile.kotlin.inject.anvil.OPTION_CONTRIBUTING_ANNOTATIONS
+import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 import software.amazon.lastmile.kotlin.inject.anvil.compile
 import software.amazon.lastmile.kotlin.inject.anvil.componentInterface
 import software.amazon.lastmile.kotlin.inject.anvil.mergedComponent
-import software.amazon.test.Singleton
 
 private const val CONTRIBUTING_ANNOTATION =
     "software.amazon.lastmile.kotlin.inject.anvil.extend.ContributingAnnotation"
@@ -64,6 +65,7 @@ class CustomSymbolProcessorTest {
         
                 import me.tatarka.inject.annotations.Component
                 import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
+                import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
                 import kotlin.annotation.AnnotationTarget.CLASS
 
                 $markerAnnotation
@@ -74,8 +76,8 @@ class CustomSymbolProcessorTest {
                 class Renderer
     
                 @Component
-                @MergeComponent
-                @Singleton
+                @MergeComponent(Unit::class)
+                @SingleIn(Unit::class)
                 interface ComponentInterface : ComponentInterfaceMerged {
                     val string: String
                 }
@@ -132,13 +134,14 @@ class CustomSymbolProcessorTest {
         
                 import me.tatarka.inject.annotations.Component
                 import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
+                import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
                 
                 @ContributesRenderer
                 class Renderer
     
                 @Component
-                @MergeComponent
-                @Singleton
+                @MergeComponent(Unit::class)
+                @SingleIn(Unit::class)
                 interface ComponentInterface : ComponentInterfaceMerged {
                     val string: String
                 }
@@ -167,8 +170,16 @@ class CustomSymbolProcessorTest {
                                     TypeSpec
                                         .interfaceBuilder(componentClassName)
                                         .addOriginatingKSFile(clazz.containingFile!!)
-                                        .addAnnotation(ContributesTo::class)
-                                        .addAnnotation(Singleton::class)
+                                        .addAnnotation(
+                                            AnnotationSpec.builder(ContributesTo::class)
+                                                .addMember("Unit::class")
+                                                .build(),
+                                        )
+                                        .addAnnotation(
+                                            AnnotationSpec.builder(SingleIn::class)
+                                                .addMember("Unit::class")
+                                                .build(),
+                                        )
                                         .addFunction(
                                             FunSpec
                                                 .builder("provideString")

--- a/compiler/src/test/kotlin/software/amazon/test/Singleton.kt
+++ b/compiler/src/test/kotlin/software/amazon/test/Singleton.kt
@@ -1,7 +1,0 @@
-package software.amazon.test
-
-import me.tatarka.inject.annotations.Scope
-
-@Scope
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER)
-annotation class Singleton

--- a/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesBinding.kt
+++ b/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesBinding.kt
@@ -64,19 +64,6 @@ import kotlin.reflect.KClass
  * @ContributesBinding(AppScope::class, boundType = Base2::class, multibinding = true)
  * class Impl : Base, Base2
  * ```
- *
- * ## Custom scopes
- *
- * If you use your own scope annotations without the references such as `AppScope::class`, then
- * you can use your scope directly on the class:
- * ```
- * interface Authenticator
- *
- * @Inject
- * @Singleton
- * @ContributesBinding
- * class RealAuthenticator : Authenticator
- * ```
  */
 @Target(CLASS)
 @Repeatable
@@ -84,7 +71,7 @@ public annotation class ContributesBinding(
     /**
      * The scope in which to include this contributed binding.
      */
-    val scope: KClass<*> = Unit::class,
+    val scope: KClass<*>,
     /**
      * The type that this class is bound to. When injecting [boundType] the concrete class will be
      * this annotated class.

--- a/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesSubcomponent.kt
+++ b/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesSubcomponent.kt
@@ -101,31 +101,13 @@ import kotlin.reflect.KClass
  *     }
  * }
  * ```
- *
- *
- * ## Custom scopes
- *
- * If you use your own scope annotations without the references such as `AppScope::class`, then
- * you can use your scope directly on the class:
- * ```
- * @ContributesSubcomponent
- * @LoggedInScope
- * interface LoggedInComponent {
- *
- *     @ContributesSubcomponent.Factory
- *     @Singleton
- *     interface Factory {
- *         fun createLoggedInComponent(): LoggedInComponent
- *     }
- * }
- * ```
  */
 @Target(CLASS)
 public annotation class ContributesSubcomponent(
     /**
      * The scope in which to include this contributed component interface.
      */
-    val scope: KClass<*> = Unit::class,
+    val scope: KClass<*>,
 ) {
     /**
      * A factory for the contributed subcomponent.
@@ -140,6 +122,6 @@ public annotation class ContributesSubcomponent(
         /**
          * The scope in which to include this contributed component interface.
          */
-        val scope: KClass<*> = Unit::class,
+        val scope: KClass<*>,
     )
 }

--- a/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesTo.kt
+++ b/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesTo.kt
@@ -11,22 +11,11 @@ import kotlin.reflect.KClass
  * @ContributesTo(AppScope::class)
  * interface ComponentInterface { .. }
  * ```
- *
- *
- * ## Custom scopes
- *
- * If you use your own scope annotations without the references such as `AppScope::class`, then
- * you can use your scope directly on the class:
- * ```
- * @ContributesTo
- * @Singleton
- * interface ComponentInterface { .. }
- * ```
  */
 @Target(CLASS)
 public annotation class ContributesTo(
     /**
      * The scope in which to include this contributed component interface.
      */
-    val scope: KClass<*> = Unit::class,
+    val scope: KClass<*>,
 )

--- a/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/MergeComponent.kt
+++ b/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/MergeComponent.kt
@@ -31,27 +31,13 @@ import kotlin.reflect.KClass
  * )
  * interface AppComponent
  * ```
- *
- *
- * ## Custom scopes
- *
- * If you use your own scope annotations without the references such as `AppScope::class`, then
- * you can use your scope directly on the class:
- * ```
- * @Component
- * @MergeComponent
- * @Singleton
- * abstract class AppComponent(
- *     ...
- * ) : AppComponentMerged
- * ```
  */
 @Target(CLASS)
 public annotation class MergeComponent(
     /**
      * The scope in which to include this contributed component interface.
      */
-    val scope: KClass<*> = Unit::class,
+    val scope: KClass<*>,
 
     /**
      * List of component interfaces that are contributed to the same scope, but should be


### PR DESCRIPTION
Enforce scope parameter on all `@Contributes*` annotations and stop using the kotlin-inject scope implicitly. This aligns the library with the original Anvil implementation for Dagger 2 and brings more consistency.

Resolves #36