### PR TITLE
Make the generated property private for `@ContributingAnnotation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 * **BREAKING CHANGE:** Enforce scope parameter on all `@Contributes*` annotations and stop using the kotlin-inject scope implicitly, see #36.
+* Made the generated property when using `@ContributingAnnotation` private. There is no reason to expose the property on the compile classpath.
 
 ### Deprecated
 

--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/extend/ContributingAnnotationProcessor.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/extend/ContributingAnnotationProcessor.kt
@@ -72,7 +72,7 @@ internal class ContributingAnnotationProcessor(
                     .builder(
                         name = clazz.safeClassName.decapitalize(),
                         type = KClass::class.asClassName().parameterizedBy(clazz.toClassName()),
-                        modifiers = setOf(KModifier.PUBLIC),
+                        modifiers = setOf(KModifier.PRIVATE),
                     )
                     .initializer("%T::class", clazz.toClassName())
                     .addOriginatingKSFile(clazz.requireContainingFile())

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/CommonSourceCode.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/CommonSourceCode.kt
@@ -5,7 +5,7 @@ package software.amazon.lastmile.kotlin.inject.anvil
 import com.tschuchort.compiletesting.JvmCompilationResult
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import software.amazon.lastmile.kotlin.inject.anvil.internal.Origin
-import java.lang.reflect.Method
+import java.lang.reflect.Field
 import java.lang.reflect.Modifier
 
 internal val JvmCompilationResult.componentInterface: Class<*>
@@ -47,13 +47,11 @@ private val Class<*>.propertyClass: Class<*>
             "Kt",
     )
 
-internal val Class<*>.propertyMethodGetter: Method
-    get() = propertyClass.methods
-        .filter { Modifier.isStatic(it.modifiers) }
-        .single { '$' !in it.name }
+internal val Class<*>.generatedProperty: Field
+    get() = propertyClass.declaredFields.single().also { it.isAccessible = true }
 
 internal val Class<*>.propertyAnnotations: Array<out Annotation>
-    get() = propertyClass.methods
+    get() = propertyClass.declaredMethods
         .filter { Modifier.isStatic(it.modifiers) }
         .single { it.name.endsWith("\$annotations") }
         .annotations

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/extend/ContributingAnnotationProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/extend/ContributingAnnotationProcessorTest.kt
@@ -10,9 +10,9 @@ import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.jupiter.api.Test
 import software.amazon.lastmile.kotlin.inject.anvil.compile
 import software.amazon.lastmile.kotlin.inject.anvil.contributesRenderer
+import software.amazon.lastmile.kotlin.inject.anvil.generatedProperty
 import software.amazon.lastmile.kotlin.inject.anvil.internal.Origin
 import software.amazon.lastmile.kotlin.inject.anvil.propertyAnnotations
-import software.amazon.lastmile.kotlin.inject.anvil.propertyMethodGetter
 import kotlin.reflect.KClass
 
 class ContributingAnnotationProcessorTest {
@@ -31,13 +31,13 @@ class ContributingAnnotationProcessorTest {
             annotation class ContributesRenderer
             """,
         ) {
-            val propertyGetter = contributesRenderer.propertyMethodGetter
+            val property = contributesRenderer.generatedProperty
 
             // The type parameter gets erased at runtime.
-            assertThat(propertyGetter.returnType.kotlin).isEqualTo(KClass::class)
+            assertThat(property.type.kotlin).isEqualTo(KClass::class)
 
             // Checks the returned type.
-            assertThat(propertyGetter.invoke(null)).isEqualTo(contributesRenderer.kotlin)
+            assertThat(property.get(null)).isEqualTo(contributesRenderer.kotlin)
 
             // The @Origin annotation is present.
             assertThat(


### PR DESCRIPTION
There is no reason to expose the generated property on the compile classpath.