### PR TITLE
Add `PROPERTY` and `TYPE` targets to `ForScope`

### DIFF
--- a/runtime-optional/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ForScope.kt
+++ b/runtime-optional/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ForScope.kt
@@ -4,7 +4,9 @@ import me.tatarka.inject.annotations.Qualifier
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.annotation.AnnotationTarget.PROPERTY
 import kotlin.annotation.AnnotationTarget.PROPERTY_GETTER
+import kotlin.annotation.AnnotationTarget.TYPE
 import kotlin.annotation.AnnotationTarget.VALUE_PARAMETER
 import kotlin.reflect.KClass
 
@@ -27,7 +29,7 @@ import kotlin.reflect.KClass
  */
 @Qualifier
 @Retention(RUNTIME)
-@Target(CLASS, FUNCTION, PROPERTY_GETTER, VALUE_PARAMETER)
+@Target(CLASS, FUNCTION, PROPERTY_GETTER, VALUE_PARAMETER, TYPE, PROPERTY)
 public expect annotation class ForScope(
     /**
      * The marker that identifies this scope.

--- a/runtime-optional/src/jvmAndAndroid/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ForScope.kt
+++ b/runtime-optional/src/jvmAndAndroid/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ForScope.kt
@@ -3,7 +3,9 @@ package software.amazon.lastmile.kotlin.inject.anvil
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.annotation.AnnotationTarget.PROPERTY
 import kotlin.annotation.AnnotationTarget.PROPERTY_GETTER
+import kotlin.annotation.AnnotationTarget.TYPE
 import kotlin.annotation.AnnotationTarget.VALUE_PARAMETER
 import kotlin.reflect.KClass
 
@@ -27,7 +29,7 @@ import kotlin.reflect.KClass
 @me.tatarka.inject.annotations.Qualifier
 @javax.inject.Qualifier
 @Retention(RUNTIME)
-@Target(CLASS, FUNCTION, PROPERTY_GETTER, VALUE_PARAMETER)
+@Target(CLASS, FUNCTION, PROPERTY_GETTER, VALUE_PARAMETER, TYPE, PROPERTY)
 public actual annotation class ForScope(
     /**
      * The marker that identifies this scope.

--- a/runtime-optional/src/nonJvmAndAndroid/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ForScope.kt
+++ b/runtime-optional/src/nonJvmAndAndroid/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ForScope.kt
@@ -4,7 +4,9 @@ import me.tatarka.inject.annotations.Qualifier
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.annotation.AnnotationTarget.PROPERTY
 import kotlin.annotation.AnnotationTarget.PROPERTY_GETTER
+import kotlin.annotation.AnnotationTarget.TYPE
 import kotlin.annotation.AnnotationTarget.VALUE_PARAMETER
 import kotlin.reflect.KClass
 
@@ -24,7 +26,7 @@ import kotlin.reflect.KClass
  */
 @Qualifier
 @Retention(RUNTIME)
-@Target(CLASS, FUNCTION, PROPERTY_GETTER, VALUE_PARAMETER)
+@Target(CLASS, FUNCTION, PROPERTY_GETTER, VALUE_PARAMETER, TYPE, PROPERTY)
 public actual annotation class ForScope(
     /**
      * The marker that identifies this scope.


### PR DESCRIPTION
That was an oversight and they should have been there from the beginning. Without them you wouldn't be allowed to add the annotation to abstract properties, e.g.
```kotlin
interface Abc {
  @ForScope(Unit::class)
  val def: Def
}
```