### PR TITLE
Use KSP2 in some tests

### DIFF
--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/Compilation.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/Compilation.kt
@@ -34,6 +34,7 @@ class Compilation internal constructor(
     fun configureKotlinInjectAnvilProcessor(
         processorOptions: Map<String, String> = emptyMap(),
         symbolProcessorProviders: Set<SymbolProcessorProvider> = emptySet(),
+        useKsp2: Boolean = true,
     ): Compilation = apply {
         checkNotCompiled()
         check(!processorsConfigured) { "Processor should not be configured twice." }
@@ -41,8 +42,6 @@ class Compilation internal constructor(
         processorsConfigured = true
 
         with(kotlinCompilation) {
-            val useKsp2 = false
-
             if (!useKsp2) {
                 languageVersion = "1.9"
             }
@@ -144,6 +143,7 @@ fun compile(
     workingDir: File? = null,
     previousCompilationResult: JvmCompilationResult? = null,
     moduleName: String? = null,
+    useKsp2: Boolean = true,
     exitCode: KotlinCompilation.ExitCode = KotlinCompilation.ExitCode.OK,
     block: JvmCompilationResult.() -> Unit = { },
 ): JvmCompilationResult {
@@ -164,7 +164,7 @@ fun compile(
                 addPreviousCompilationResult(previousCompilationResult)
             }
         }
-        .configureKotlinInjectAnvilProcessor()
+        .configureKotlinInjectAnvilProcessor(useKsp2 = useKsp2)
         .compile(*sources)
         .also {
             if (exitCode == KotlinCompilation.ExitCode.OK) {

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesSubcomponentProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesSubcomponentProcessorTest.kt
@@ -61,6 +61,7 @@ class ContributesSubcomponentProcessorTest {
             }
             """,
             scopesSource,
+            useKsp2 = false,
         ) {
             val component = componentInterface.newComponent<Any>()
             val childComponent = component::class.java.methods
@@ -133,7 +134,7 @@ class ContributesSubcomponentProcessorTest {
                 addPreviousCompilationResult(previousResult2)
                 addPreviousCompilationResult(previousResult3)
             }
-            .configureKotlinInjectAnvilProcessor()
+            .configureKotlinInjectAnvilProcessor(useKsp2 = false)
             .compile(
                 """
                 package software.amazon.test
@@ -208,6 +209,7 @@ class ContributesSubcomponentProcessorTest {
             }
             """,
             scopesSource,
+            useKsp2 = false,
         ) {
             val components = listOf<Any>(
                 componentInterface.newComponent(),
@@ -309,6 +311,7 @@ class ContributesSubcomponentProcessorTest {
             }
             """,
             scopesSource,
+            useKsp2 = false,
         ) {
             val component = componentInterface.newComponent<Any>()
             val childComponent = component::class.java.methods
@@ -366,6 +369,7 @@ class ContributesSubcomponentProcessorTest {
             }
             """,
             scopesSource,
+            useKsp2 = false,
         ) {
             val component = componentInterface.newComponent<Any>()
             val childComponent = component::class.java.methods

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/MergeComponentProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/MergeComponentProcessorTest.kt
@@ -59,6 +59,7 @@ class MergeComponentProcessorTest {
                 abstract val base: Base
             }
             """,
+            useKsp2 = false,
         ) {
             assertThat(componentInterface.mergedComponent).isNotNull()
 
@@ -205,6 +206,7 @@ class MergeComponentProcessorTest {
             }
             """,
             previousCompilationResult = previousCompilation,
+            useKsp2 = false,
         ) {
             assertThat(componentInterface.mergedComponent).isNotNull()
 
@@ -251,6 +253,7 @@ class MergeComponentProcessorTest {
                 abstract val base: Base
             }
             """,
+            useKsp2 = false,
         ) {
             assertThat(componentInterface.mergedComponent).isNotNull()
 
@@ -297,6 +300,7 @@ class MergeComponentProcessorTest {
                 abstract val base: Base
             }
             """,
+            useKsp2 = false,
         ) {
             assertThat(componentInterface.mergedComponent).isNotNull()
 
@@ -343,6 +347,7 @@ class MergeComponentProcessorTest {
                 abstract val base: Base
             }
             """,
+            useKsp2 = false,
         ) {
             assertThat(componentInterface.mergedComponent).isNotNull()
 

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/extend/CustomSymbolProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/extend/CustomSymbolProcessorTest.kt
@@ -60,6 +60,7 @@ class CustomSymbolProcessorTest {
             .configureKotlinInjectAnvilProcessor(
                 processorOptions = options,
                 symbolProcessorProviders = setOf(symbolProcessorProvider),
+                useKsp2 = false,
             )
             .compile(
                 """
@@ -128,6 +129,7 @@ class CustomSymbolProcessorTest {
             .configureKotlinInjectAnvilProcessor(
                 processorOptions = options,
                 symbolProcessorProviders = setOf(symbolProcessorProvider),
+                useKsp2 = false,
             )
             .addPreviousCompilationResult(previousCompilation)
             .compile(
@@ -170,6 +172,7 @@ class CustomSymbolProcessorTest {
         Compilation()
             .configureKotlinInjectAnvilProcessor(
                 symbolProcessorProviders = setOf(symbolProcessorProvider),
+                useKsp2 = false,
             )
             .compile(
                 """


### PR DESCRIPTION
Use KSP2 in the unit tests that allow it. KSP2 cannot be used with kotlin-inject when `@Component` annotations are processed.