### PR TITLE
Upgrade KSP

### DIFF
--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -36,4 +36,5 @@ dependencies {
 
     // Bump transitive dependency.
     testImplementation libs.ksp
+    testImplementation libs.ksp.embeddable
 }

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/Compilation.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/Compilation.kt
@@ -34,7 +34,6 @@ class Compilation internal constructor(
     fun configureKotlinInjectAnvilProcessor(
         processorOptions: Map<String, String> = emptyMap(),
         symbolProcessorProviders: Set<SymbolProcessorProvider> = emptySet(),
-        useKsp2: Boolean = true,
     ): Compilation = apply {
         checkNotCompiled()
         check(!processorsConfigured) { "Processor should not be configured twice." }
@@ -42,11 +41,7 @@ class Compilation internal constructor(
         processorsConfigured = true
 
         with(kotlinCompilation) {
-            if (!useKsp2) {
-                languageVersion = "1.9"
-            }
-
-            configureKsp(useKsp2 = useKsp2) {
+            configureKsp(useKsp2 = true) {
                 this.symbolProcessorProviders += ServiceLoader.load(
                     SymbolProcessorProvider::class.java,
                     SymbolProcessorProvider::class.java.classLoader,
@@ -143,7 +138,6 @@ fun compile(
     workingDir: File? = null,
     previousCompilationResult: JvmCompilationResult? = null,
     moduleName: String? = null,
-    useKsp2: Boolean = true,
     exitCode: KotlinCompilation.ExitCode = KotlinCompilation.ExitCode.OK,
     block: JvmCompilationResult.() -> Unit = { },
 ): JvmCompilationResult {
@@ -164,7 +158,7 @@ fun compile(
                 addPreviousCompilationResult(previousCompilationResult)
             }
         }
-        .configureKotlinInjectAnvilProcessor(useKsp2 = useKsp2)
+        .configureKotlinInjectAnvilProcessor()
         .compile(*sources)
         .also {
             if (exitCode == KotlinCompilation.ExitCode.OK) {

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesSubcomponentProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesSubcomponentProcessorTest.kt
@@ -61,7 +61,6 @@ class ContributesSubcomponentProcessorTest {
             }
             """,
             scopesSource,
-            useKsp2 = false,
         ) {
             val component = componentInterface.newComponent<Any>()
             val childComponent = component::class.java.methods
@@ -134,7 +133,7 @@ class ContributesSubcomponentProcessorTest {
                 addPreviousCompilationResult(previousResult2)
                 addPreviousCompilationResult(previousResult3)
             }
-            .configureKotlinInjectAnvilProcessor(useKsp2 = false)
+            .configureKotlinInjectAnvilProcessor()
             .compile(
                 """
                 package software.amazon.test
@@ -209,7 +208,6 @@ class ContributesSubcomponentProcessorTest {
             }
             """,
             scopesSource,
-            useKsp2 = false,
         ) {
             val components = listOf<Any>(
                 componentInterface.newComponent(),
@@ -311,7 +309,6 @@ class ContributesSubcomponentProcessorTest {
             }
             """,
             scopesSource,
-            useKsp2 = false,
         ) {
             val component = componentInterface.newComponent<Any>()
             val childComponent = component::class.java.methods
@@ -369,7 +366,6 @@ class ContributesSubcomponentProcessorTest {
             }
             """,
             scopesSource,
-            useKsp2 = false,
         ) {
             val component = componentInterface.newComponent<Any>()
             val childComponent = component::class.java.methods

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/MergeComponentProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/MergeComponentProcessorTest.kt
@@ -59,7 +59,6 @@ class MergeComponentProcessorTest {
                 abstract val base: Base
             }
             """,
-            useKsp2 = false,
         ) {
             assertThat(componentInterface.mergedComponent).isNotNull()
 
@@ -206,7 +205,6 @@ class MergeComponentProcessorTest {
             }
             """,
             previousCompilationResult = previousCompilation,
-            useKsp2 = false,
         ) {
             assertThat(componentInterface.mergedComponent).isNotNull()
 
@@ -253,7 +251,6 @@ class MergeComponentProcessorTest {
                 abstract val base: Base
             }
             """,
-            useKsp2 = false,
         ) {
             assertThat(componentInterface.mergedComponent).isNotNull()
 
@@ -300,7 +297,6 @@ class MergeComponentProcessorTest {
                 abstract val base: Base
             }
             """,
-            useKsp2 = false,
         ) {
             assertThat(componentInterface.mergedComponent).isNotNull()
 
@@ -347,7 +343,6 @@ class MergeComponentProcessorTest {
                 abstract val base: Base
             }
             """,
-            useKsp2 = false,
         ) {
             assertThat(componentInterface.mergedComponent).isNotNull()
 

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/extend/CustomSymbolProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/extend/CustomSymbolProcessorTest.kt
@@ -60,7 +60,6 @@ class CustomSymbolProcessorTest {
             .configureKotlinInjectAnvilProcessor(
                 processorOptions = options,
                 symbolProcessorProviders = setOf(symbolProcessorProvider),
-                useKsp2 = false,
             )
             .compile(
                 """
@@ -129,7 +128,6 @@ class CustomSymbolProcessorTest {
             .configureKotlinInjectAnvilProcessor(
                 processorOptions = options,
                 symbolProcessorProviders = setOf(symbolProcessorProvider),
-                useKsp2 = false,
             )
             .addPreviousCompilationResult(previousCompilation)
             .compile(
@@ -172,7 +170,6 @@ class CustomSymbolProcessorTest {
         Compilation()
             .configureKotlinInjectAnvilProcessor(
                 symbolProcessorProviders = setOf(symbolProcessorProvider),
-                useKsp2 = false,
             )
             .compile(
                 """

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.caching=true
 
 kotlin.code.style=official
 kotlin.mpp.stability.nowarn=true
-ksp.useKSP2=false
+ksp.useKSP2=true
 
 # This property does not work when setting up publishing through the DSL as we do.
 # SONATYPE_AUTOMATIC_RELEASE=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ kotlin-hierarchy = "1.1"
 kotlin-inject = "0.7.2"
 kotlin-poet = "1.18.1"
 kotlinx-binaryCompatibilityValidator = "0.16.3"
-ksp = "2.0.21-1.0.25"
+ksp = "2.0.21-1.0.26"
 ktlint-binary = "1.2.1"
 ktlint-gradle = "12.1.1"
 maven-publish = "0.29.0"
@@ -43,6 +43,7 @@ kotlin-poet-ksp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotli
 ksp-gradle-plugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 ksp = { module = "com.google.devtools.ksp:symbol-processing", version.ref = "ksp" }
 ksp-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
+ksp-embeddable = { module = "com.google.devtools.ksp:symbol-processing-aa-embeddable", version.ref = "ksp" }
 ktlint-gradle-plugin = { module = "org.jlleitschuh.gradle:ktlint-gradle", version.ref = "ktlint-gradle" }
 maven-publish-gradle-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "maven-publish" }
 


### PR DESCRIPTION
Upgrade KSP and enable KSP2 by default. KSP2 couldn't be enabled before due to bugs that were triggered by kotlin-inject.
