### PR TITLE
Support `@Component` annotations in a MergedComponent

### DIFF
--- a/compiler-utils/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContextAware.kt
+++ b/compiler-utils/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContextAware.kt
@@ -15,6 +15,7 @@ import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSValueParameter
 import com.google.devtools.ksp.symbol.Visibility
+import me.tatarka.inject.annotations.Component
 import me.tatarka.inject.annotations.Qualifier
 import me.tatarka.inject.annotations.Scope
 import software.amazon.lastmile.kotlin.inject.anvil.internal.Origin
@@ -29,6 +30,7 @@ interface ContextAware {
 
     private val scopeFqName get() = Scope::class.requireQualifiedName()
     private val qualifierFqName get() = Qualifier::class.requireQualifiedName()
+    private val componentFqName get() = Component::class.requireQualifiedName()
 
     fun <T : Any> requireNotNull(
         value: T?,
@@ -107,6 +109,10 @@ interface ContextAware {
         return declaration.annotations.any {
             it.annotationType.resolve().declaration.requireQualifiedName() == qualifierFqName
         }
+    }
+
+    fun KSAnnotation.isKotlinInjectComponentAnnotation(): Boolean {
+        return annotationType.resolve().declaration.requireQualifiedName() == componentFqName
     }
 
     private fun KSAnnotation.hasScopeParameter(): Boolean {

--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/GenerateKotlinInjectComponentProcessor.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/GenerateKotlinInjectComponentProcessor.kt
@@ -208,7 +208,7 @@ internal class GenerateKotlinInjectComponentProcessor(
 
     /**
      * Creates a custom name for parameters of the new Kotlin Inject interface
-     * as to not require parameters to be open
+     * as to not require parameters to be open.
      */
     private fun KSValueParameter.requireDelegateName(): String {
         return "${this.requireName()}Delegate"

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/GenerateKotlinInjectComponentProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/GenerateKotlinInjectComponentProcessorTest.kt
@@ -158,6 +158,49 @@ class GenerateKotlinInjectComponentProcessorTest {
     }
 
     @Test
+    fun `an abstract class supports parameters`() {
+        compile(
+            """
+            package software.amazon.test
+                            
+            import me.tatarka.inject.annotations.Inject
+            import me.tatarka.inject.annotations.Provides
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+            import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
+            import software.amazon.lastmile.kotlin.inject.anvil.ForScope
+            import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
+
+            interface Base
+
+            @Inject
+            @SingleIn(AppScope::class)
+            @ContributesBinding(AppScope::class)
+            class Impl(@ForScope(AppScope::class) val string: String, val int: Int) : Base {
+                override fun toString(): String = string + int
+            }
+
+            @MergeComponent(AppScope::class)
+            @SingleIn(AppScope::class)
+            abstract class ComponentInterface(
+                @get:Provides @get:ForScope(AppScope::class) val string: String,
+                @get:Provides val int: Int,
+            ) {
+                abstract val base: Base
+            }
+            """,
+        ) {
+            val component = componentInterface.kotlinInjectComponent.newComponent<Any>("", 5)
+
+            val implValue = component::class.java.methods
+                .single { it.name == "getBase" }
+                .invoke(component)
+
+            assertThat(impl.isInstance(implValue)).isTrue()
+        }
+    }
+
+    @Test
     fun `an abstract class supports component parameters`() {
         compile(
             """

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/GenerateKotlinInjectComponentProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/GenerateKotlinInjectComponentProcessorTest.kt
@@ -220,7 +220,7 @@ class GenerateKotlinInjectComponentProcessorTest {
             @MergeComponent(AppScope::class)
             @SingleIn(AppScope::class)
             abstract class ComponentInterface(
-                @Component open val childComponent: ChildComponent,
+                @Component val childComponent: ChildComponent,
             ) {
                 abstract val string: String
             }

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/GenerateKotlinInjectComponentProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/GenerateKotlinInjectComponentProcessorTest.kt
@@ -197,6 +197,8 @@ class GenerateKotlinInjectComponentProcessorTest {
                 .invoke(component)
 
             assertThat(impl.isInstance(implValue)).isTrue()
+
+            assertThat(component::class.companionObject).isNotNull()
         }
     }
 
@@ -241,9 +243,7 @@ class GenerateKotlinInjectComponentProcessorTest {
                 .single { it.name == "getString" }
                 .invoke(component)
 
-            assertThat(impl.isInstance(implValue)).isTrue()
-
-            assertThat(component::class.companionObject).isNotNull()
+            assertThat(implValue).isEqualTo("test")
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/amzn/kotlin-inject-anvil/issues/76

*Description of changes:*

Checks if you have a component annotation and ensures that the annotation continues on, as well as marking it as a value and is an override.

```kotlin
@MergeComponent(AppScope::class)
@SingleIn(AppScope::class)
abstract class ComponentInterface(
    @Component val childComponent: ChildComponent,
)
```

generates

```kotlin
@Origin(value = ComponentInterface::class)
@Component
@MergeComponent(
  scope = AppScope::class,
  exclude = arrayOf(),
)
@SingleIn(scope = AppScope::class)
public abstract class KotlinInjectComponentInterface(
  @Component
  override val childComponentDelegate: ChildComponent,
) : ComponentInterface(childComponentDelegate),
    KotlinInjectComponentInterfaceMerged {
  public companion object
}
```

