### PR TITLE
Copy required annotations to generated code

### DIFF
--- a/build-logic/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/gradle/KotlinPlugin.kt
+++ b/build-logic/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/gradle/KotlinPlugin.kt
@@ -12,6 +12,7 @@ import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.compile.JavaCompile
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
 import java.io.File
@@ -33,9 +34,11 @@ internal open class KotlinPlugin : Plugin<Project> {
     }
 
     private fun Project.configureKotlinCompile() {
-        tasks.withType(KotlinJvmCompile::class.java).configureEach {
-            it.compilerOptions.jvmTarget.set(JvmTarget.fromTarget(javaVersion.toString()))
+        tasks.withType(KotlinCompilationTask::class.java).configureEach {
             it.compilerOptions.allWarningsAsErrors.set(ci)
+            if (it is KotlinJvmCompile) {
+                it.compilerOptions.jvmTarget.set(JvmTarget.fromTarget(javaVersion.toString()))
+            }
         }
     }
 


### PR DESCRIPTION
Copy all annotations from `expect fun` functions annotated with `@CreateComponent` to the generated `actual fun` functions to avoid a Kotlin compiler warning.