### PR TITLE
Add support for multi-binding map codegen

### DIFF
--- a/compiler-utils/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/MapKeyAnnotation.kt
+++ b/compiler-utils/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/MapKeyAnnotation.kt
@@ -1,0 +1,22 @@
+package software.amazon.lastmile.kotlin.inject.anvil
+
+import com.google.devtools.ksp.symbol.KSValueArgument
+
+/**
+ * Represents the key under which the contributed
+ * element will be added to the multi-binding `Map`.
+ *
+ * ```
+ * @MapKey
+ * annotation class MyMapKey(val value: String)
+ *
+ * @Inject
+ * @ContributesBinding(AppScope::class, multibinding = true)
+ * @MyMapKey("foo")
+ * class Impl : Base
+ * ```
+ * Where `MyMapKey` would represent the "MapKeyAnnotation".
+ */
+data class MapKeyAnnotation(
+    val argument: KSValueArgument
+)

--- a/compiler-utils/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/Util.kt
+++ b/compiler-utils/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/Util.kt
@@ -7,6 +7,10 @@ import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSValueArgument
 import com.squareup.kotlinpoet.Annotatable
 import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.ParameterizedTypeName
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.ksp.toClassName
 import software.amazon.lastmile.kotlin.inject.anvil.internal.Origin
 import java.util.Locale
@@ -96,4 +100,10 @@ fun KSDeclaration.requireQualifiedName(contextAware: ContextAware): String =
  */
 fun KClass<*>.requireQualifiedName(): String = requireNotNull(qualifiedName) {
     "Qualified name was null for $this"
+}
+
+fun pairTypeOf(vararg typeNames: TypeName): ParameterizedTypeName {
+    return Pair::class
+        .asTypeName()
+        .parameterizedBy(*typeNames)
 }

--- a/compiler-utils/src/testFixtures/kotlin/software/amazon/lastmile/kotlin/inject/anvil/Asserts.kt
+++ b/compiler-utils/src/testFixtures/kotlin/software/amazon/lastmile/kotlin/inject/anvil/Asserts.kt
@@ -15,6 +15,7 @@ import assertk.assertions.isEqualTo
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import java.lang.reflect.AnnotatedElement
+import java.lang.reflect.ParameterizedType
 import kotlin.reflect.KClass
 
 fun Assert<AnnotatedElement>.isAnnotatedWith(annotation: KClass<*>) {
@@ -43,4 +44,17 @@ fun Assert<ExitCode>.isError() {
             -> ExitCode.COMPILATION_ERROR
         }
     }.isEqualTo(ExitCode.COMPILATION_ERROR)
+}
+
+fun Assert<ParameterizedType>.isPairOf(
+    first: Class<*>,
+    second: Class<*>,
+) {
+    transform { element ->
+        element.rawType
+    }.isEqualTo(Pair::class.java)
+
+    transform { element ->
+        element.actualTypeArguments
+    }.isEqualTo(arrayOf(first, second))
 }

--- a/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesBinding.kt
+++ b/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesBinding.kt
@@ -64,6 +64,19 @@ import kotlin.reflect.KClass
  * @ContributesBinding(AppScope::class, boundType = Base2::class, multibinding = true)
  * class Impl : Base, Base2
  * ```
+ *
+ * If the class is annotated with a [MapKey] annotation, then the binding will be contributed
+ * to a multi-binding `Map` instead of a `Set`.
+ *
+ * ```
+ * @MapKey
+ * annotation class MyMapKey(val value: String)
+ *
+ * @Inject
+ * @ContributesBinding(AppScope::class, multibinding = true)
+ * @MyMapKey("foo")
+ * class Impl : Base
+ * ```
  */
 @Target(CLASS)
 @Repeatable

--- a/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/MapKey.kt
+++ b/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/MapKey.kt
@@ -1,0 +1,50 @@
+package software.amazon.lastmile.kotlin.inject.anvil
+
+import kotlin.reflect.KClass
+
+/**
+ * Marks an annotation class as a key for a multi-binding `Map`.
+ *
+ * When used with a [ContributesBinding] annotation, this annotation specifies the key under
+ * which the contributed element will be added to the map.
+ *
+ * ```
+ * @MapKey
+ * annotation class MyMapKey(val value: String)
+ *
+ * @Inject
+ * @ContributesBinding(AppScope::class, multibinding = true)
+ * @MyMapKey("foo")
+ * class Impl : Base
+ * ```
+ */
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+public annotation class MapKey
+
+@MapKey
+@Target(AnnotationTarget.CLASS)
+@Repeatable
+public annotation class StringKey(
+    val value: String,
+)
+
+@MapKey
+@Target(AnnotationTarget.CLASS)
+@Repeatable
+public annotation class IntKey(
+    val value: Int,
+)
+
+@MapKey
+@Target(AnnotationTarget.CLASS)
+@Repeatable
+public annotation class LongKey(
+    val value: Long,
+)
+
+@MapKey
+@Target(AnnotationTarget.CLASS)
+@Repeatable
+public annotation class ClassKey(
+    val value: KClass<*>,
+)


### PR DESCRIPTION
Add support for contributing to a map multibinding with a new `MapKey` annotation. This new annotation is repeatable, so that we can contribute the same binding with multiple keys.

Fixes #48 

Credits to https://github.com/r0adkll/kimchi for the mapkey codegen
