### PR TITLE
Allow other access modifiers

### DIFF
--- a/compiler-utils/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContextAware.kt
+++ b/compiler-utils/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContextAware.kt
@@ -65,6 +65,13 @@ interface ContextAware {
         check(declaration.getVisibility() == Visibility.PUBLIC, declaration, lazyMessage)
     }
 
+    fun checkNotPrivate(
+        declaration: KSDeclaration,
+        lazyMessage: () -> String = { "Contribute component interfaces must not be private." },
+    ) {
+        check(declaration.getVisibility() != Visibility.PRIVATE, declaration, lazyMessage)
+    }
+
     fun checkIsInterface(
         clazz: KSClassDeclaration,
         lazyMessage: () -> String = { "Only interfaces can be contributed." },

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testImplementation libs.assertk
     testImplementation libs.kotlin.compile.testing.core
     testImplementation libs.kotlin.compile.testing.ksp
+    testImplementation libs.kotlin.reflect
 
     testImplementation platform(libs.junit.jupiter.bom)
     testImplementation libs.junit.jupiter.core

--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/GenerateKotlinInjectComponentProcessor.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/GenerateKotlinInjectComponentProcessor.kt
@@ -13,14 +13,11 @@ import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSValueParameter
-import com.google.devtools.ksp.symbol.Visibility
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.KModifier.ABSTRACT
-import com.squareup.kotlinpoet.KModifier.INTERNAL
-import com.squareup.kotlinpoet.KModifier.PROTECTED
 import com.squareup.kotlinpoet.KModifier.PUBLIC
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
@@ -30,6 +27,7 @@ import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
 import com.squareup.kotlinpoet.ksp.toAnnotationSpec
 import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.toKModifier
 import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.writeTo
 import me.tatarka.inject.annotations.Component
@@ -220,14 +218,6 @@ internal class GenerateKotlinInjectComponentProcessor(
     }
 
     private fun KSClassDeclaration.getAccessModifier(): KModifier {
-        return when (getVisibility()) {
-            Visibility.PUBLIC -> PUBLIC
-            Visibility.PRIVATE -> error("Visibility cannot be private")
-            Visibility.INTERNAL -> INTERNAL
-            Visibility.LOCAL,
-            Visibility.JAVA_PACKAGE,
-            Visibility.PROTECTED,
-            -> PROTECTED
-        }
+        return getVisibility().toKModifier() ?: PUBLIC
     }
 }

--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/GenerateKotlinInjectComponentProcessor.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/GenerateKotlinInjectComponentProcessor.kt
@@ -20,7 +20,6 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.KModifier.ABSTRACT
 import com.squareup.kotlinpoet.KModifier.INTERNAL
-import com.squareup.kotlinpoet.KModifier.PRIVATE
 import com.squareup.kotlinpoet.KModifier.PROTECTED
 import com.squareup.kotlinpoet.KModifier.PUBLIC
 import com.squareup.kotlinpoet.ParameterSpec
@@ -223,7 +222,7 @@ internal class GenerateKotlinInjectComponentProcessor(
     private fun KSClassDeclaration.getAccessModifier(): KModifier {
         return when (getVisibility()) {
             Visibility.PUBLIC -> PUBLIC
-            Visibility.PRIVATE -> PRIVATE
+            Visibility.PRIVATE -> error("Visibility cannot be private")
             Visibility.INTERNAL -> INTERNAL
             Visibility.LOCAL,
             Visibility.JAVA_PACKAGE,

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/GenerateKotlinInjectComponentProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/GenerateKotlinInjectComponentProcessorTest.kt
@@ -249,7 +249,7 @@ class GenerateKotlinInjectComponentProcessorTest {
     }
 
     @Test
-    fun `an internal abstract class`() {
+    fun `internal visibility for component interface is supported for an abstract class`() {
         compile(
             """
             package software.amazon.test
@@ -272,7 +272,7 @@ class GenerateKotlinInjectComponentProcessorTest {
     }
 
     @Test
-    fun `an internal interface`() {
+    fun `internal visibility for component interface is supported`() {
         compile(
             """
             package software.amazon.test

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/GenerateKotlinInjectComponentProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/GenerateKotlinInjectComponentProcessorTest.kt
@@ -248,6 +248,50 @@ class GenerateKotlinInjectComponentProcessorTest {
     }
 
     @Test
+    fun `an internal abstract class`() {
+        compile(
+            """
+            package software.amazon.test
+                            
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+            import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
+
+
+            @MergeComponent(AppScope::class)
+            @SingleIn(AppScope::class)
+            internal abstract class ComponentInterface
+            """,
+        ) {
+            val component = componentInterface.kotlinInjectComponent.newComponent<Any>()
+
+            assertThat(component::class.companionObject).isNotNull()
+        }
+    }
+
+    @Test
+    fun `an internal interface`() {
+        compile(
+            """
+            package software.amazon.test
+                            
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+            import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
+
+
+            @MergeComponent(AppScope::class)
+            @SingleIn(AppScope::class)
+            internal interface ComponentInterface
+            """,
+        ) {
+            val component = componentInterface.kotlinInjectComponent.newComponent<Any>()
+
+            assertThat(component::class.companionObject).isNotNull()
+        }
+    }
+
+    @Test
     fun `the kotlin-inject component is generated with merged components without a scope`() {
         compile(
             """

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/GenerateKotlinInjectComponentProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/GenerateKotlinInjectComponentProcessorTest.kt
@@ -17,6 +17,7 @@ import software.amazon.lastmile.kotlin.inject.anvil.newComponent
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 import kotlin.reflect.KClass
+import kotlin.reflect.KVisibility
 
 class GenerateKotlinInjectComponentProcessorTest {
 
@@ -265,6 +266,7 @@ class GenerateKotlinInjectComponentProcessorTest {
         ) {
             val component = componentInterface.kotlinInjectComponent.newComponent<Any>()
 
+            assertThat(component::class.visibility).isEqualTo(KVisibility.INTERNAL)
             assertThat(component::class.companionObject).isNotNull()
         }
     }
@@ -287,6 +289,7 @@ class GenerateKotlinInjectComponentProcessorTest {
         ) {
             val component = componentInterface.kotlinInjectComponent.newComponent<Any>()
 
+            assertThat(component::class.visibility).isEqualTo(KVisibility.INTERNAL)
             assertThat(component::class.companionObject).isNotNull()
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 kotlinx-binaryCompatibilityValidator = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version.ref = "kotlinx-binaryCompatibilityValidator" }
 kotlin-poet = { module = "com.squareup:kotlinpoet", version.ref = "kotlin-poet" }
 kotlin-poet-ksp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotlin-poet" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 ksp-gradle-plugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 ksp = { module = "com.google.devtools.ksp:symbol-processing", version.ref = "ksp" }
 ksp-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/amzn/kotlin-inject-anvil/issues/77

*Description of changes:*
Allows the use of `internal` or `protected` modifiers on classes and interfaces marked with `@MergeComponent`
