### PR TITLE
Support `replaces` attribute in `@ContributesBinding` and `@ContributesTo`

### DIFF
--- a/compiler-utils/src/testFixtures/kotlin/software/amazon/lastmile/kotlin/inject/anvil/CommonSourceCode.kt
+++ b/compiler-utils/src/testFixtures/kotlin/software/amazon/lastmile/kotlin/inject/anvil/CommonSourceCode.kt
@@ -17,6 +17,12 @@ import java.lang.reflect.Modifier
 val JvmCompilationResult.componentInterface: Class<*>
     get() = classLoader.loadClass("software.amazon.test.ComponentInterface")
 
+val Class<*>.kotlinInjectComponent: Class<*>
+    get() = classLoader.loadClass(
+        "$packageName.KotlinInject" +
+            canonicalName.substring(packageName.length + 1).replace(".", ""),
+    )
+
 val Class<*>.inner: Class<*>
     get() = classes.single { it.simpleName == "Inner" }
 

--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesBindingProcessor.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesBindingProcessor.kt
@@ -81,6 +81,7 @@ internal class ContributesBindingProcessor(
 
         val annotations = clazz.findAnnotationsAtLeastOne(ContributesBinding::class)
         checkNoDuplicateBoundTypes(clazz, annotations)
+        checkReplacesHasSameScope(clazz, annotations)
 
         val boundTypes = annotations
             .map {

--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesToProcessor.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesToProcessor.kt
@@ -61,6 +61,8 @@ internal class ContributesToProcessor(
     private fun generateComponentInterface(clazz: KSClassDeclaration) {
         val componentClassName = ClassName(LOOKUP_PACKAGE, clazz.safeClassName)
 
+        checkReplacesHasSameScope(clazz, listOf(clazz.findAnnotation(ContributesTo::class)))
+
         val fileSpec = FileSpec.builder(componentClassName)
             .addType(
                 TypeSpec

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesBindingProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesBindingProcessorTest.kt
@@ -314,6 +314,66 @@ class ContributesBindingProcessorTest {
         }
     }
 
+    @Test
+    fun `a replaced binding must use the same scope`() {
+        compile(
+            """
+            package software.amazon.test
+                            
+            import me.tatarka.inject.annotations.Inject
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+            import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
+
+            interface Base
+
+            @Inject
+            @ContributesBinding(AppScope::class)
+            class Impl : Base
+
+            @Inject
+            @ContributesBinding(Unit::class, replaces = [Impl::class])
+            class Fake : Base
+            """,
+            exitCode = COMPILATION_ERROR,
+        ) {
+            assertThat(messages).contains(
+                "Replaced types must use the same scope. software.amazon.test.Fake " +
+                    "uses scope Unit, but tries to replace software.amazon.test.Impl using " +
+                    "scope AppScope.",
+            )
+        }
+    }
+
+    @Test
+    fun `a replaced binding must use the same scope without named parameter`() {
+        compile(
+            """
+            package software.amazon.test
+                            
+            import me.tatarka.inject.annotations.Inject
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+            import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
+
+            interface Base
+
+            @Inject
+            @ContributesBinding(AppScope::class)
+            class Impl : Base
+
+            @Inject
+            @ContributesBinding(Unit::class, Unit::class, false, [Impl::class])
+            class Fake : Base
+            """,
+            exitCode = COMPILATION_ERROR,
+        ) {
+            assertThat(messages).contains(
+                "Replaced types must use the same scope. software.amazon.test.Fake " +
+                    "uses scope Unit, but tries to replace software.amazon.test.Impl using " +
+                    "scope AppScope.",
+            )
+        }
+    }
+
     private val JvmCompilationResult.base: Class<*>
         get() = classLoader.loadClass("software.amazon.test.Base")
 

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesToProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesToProcessorTest.kt
@@ -93,4 +93,60 @@ class ContributesToProcessorTest {
             assertThat(messages).contains("Only interfaces can be contributed.")
         }
     }
+
+    @Test
+    fun `a replaced component must use the same scope`() {
+        compile(
+            """
+            package software.amazon.test
+                            
+            import me.tatarka.inject.annotations.Inject
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+            import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
+
+            interface Base
+
+            @ContributesTo(AppScope::class)
+            interface Component1
+
+            @ContributesTo(Unit::class, replaces = [Component1::class])
+            interface Component2
+            """,
+            exitCode = COMPILATION_ERROR,
+        ) {
+            assertThat(messages).contains(
+                "Replaced types must use the same scope. software.amazon.test." +
+                    "Component2 uses scope Unit, but tries to replace software.amazon.test." +
+                    "Component1 using scope AppScope.",
+            )
+        }
+    }
+
+    @Test
+    fun `a replaced component must use the same scope without named parameter`() {
+        compile(
+            """
+            package software.amazon.test
+                            
+            import me.tatarka.inject.annotations.Inject
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+            import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
+
+            interface Base
+
+            @ContributesTo(AppScope::class)
+            interface Component1
+
+            @ContributesTo(Unit::class, [Component1::class])
+            interface Component2
+            """,
+            exitCode = COMPILATION_ERROR,
+        ) {
+            assertThat(messages).contains(
+                "Replaced types must use the same scope. software.amazon.test." +
+                    "Component2 uses scope Unit, but tries to replace software.amazon.test." +
+                    "Component1 using scope AppScope.",
+            )
+        }
+    }
 }

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/GenerateKotlinInjectComponentProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/GenerateKotlinInjectComponentProcessorTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test
 import software.amazon.lastmile.kotlin.inject.anvil.compile
 import software.amazon.lastmile.kotlin.inject.anvil.componentInterface
 import software.amazon.lastmile.kotlin.inject.anvil.inner
+import software.amazon.lastmile.kotlin.inject.anvil.kotlinInjectComponent
 import software.amazon.lastmile.kotlin.inject.anvil.newComponent
 import java.lang.reflect.Field
 import java.lang.reflect.Method
@@ -474,12 +475,6 @@ class GenerateKotlinInjectComponentProcessorTest {
 
     private val JvmCompilationResult.impl: Class<*>
         get() = classLoader.loadClass("software.amazon.test.Impl")
-
-    private val Class<*>.kotlinInjectComponent: Class<*>
-        get() = classLoader.loadClass(
-            "$packageName.KotlinInject" +
-                canonicalName.substring(packageName.length + 1).replace(".", ""),
-        )
 
     private val Class<*>.createFunction: Method
         get() = classLoader.loadClass("${canonicalName}Kt").methods.single { it.name == "create" }

--- a/runtime/api/android/runtime.api
+++ b/runtime/api/android/runtime.api
@@ -1,6 +1,7 @@
 public abstract interface annotation class software/amazon/lastmile/kotlin/inject/anvil/ContributesBinding : java/lang/annotation/Annotation {
 	public abstract fun boundType ()Ljava/lang/Class;
 	public abstract fun multibinding ()Z
+	public abstract fun replaces ()[Ljava/lang/Class;
 	public abstract fun scope ()Ljava/lang/Class;
 }
 
@@ -17,6 +18,7 @@ public abstract interface annotation class software/amazon/lastmile/kotlin/injec
 }
 
 public abstract interface annotation class software/amazon/lastmile/kotlin/inject/anvil/ContributesTo : java/lang/annotation/Annotation {
+	public abstract fun replaces ()[Ljava/lang/Class;
 	public abstract fun scope ()Ljava/lang/Class;
 }
 

--- a/runtime/api/jvm/runtime.api
+++ b/runtime/api/jvm/runtime.api
@@ -1,6 +1,7 @@
 public abstract interface annotation class software/amazon/lastmile/kotlin/inject/anvil/ContributesBinding : java/lang/annotation/Annotation {
 	public abstract fun boundType ()Ljava/lang/Class;
 	public abstract fun multibinding ()Z
+	public abstract fun replaces ()[Ljava/lang/Class;
 	public abstract fun scope ()Ljava/lang/Class;
 }
 
@@ -17,6 +18,7 @@ public abstract interface annotation class software/amazon/lastmile/kotlin/injec
 }
 
 public abstract interface annotation class software/amazon/lastmile/kotlin/inject/anvil/ContributesTo : java/lang/annotation/Annotation {
+	public abstract fun replaces ()[Ljava/lang/Class;
 	public abstract fun scope ()Ljava/lang/Class;
 }
 

--- a/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesBinding.kt
+++ b/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesBinding.kt
@@ -64,6 +64,19 @@ import kotlin.reflect.KClass
  * @ContributesBinding(AppScope::class, boundType = Base2::class, multibinding = true)
  * class Impl : Base, Base2
  * ```
+ *
+ * ## Replacement
+ *
+ * Contributed bindings can replace other contributed bindings and component interfaces with
+ * the [replaces] parameter. This is especially helpful for different bindings in tests.
+ * ```
+ * @Inject
+ * @ContributesBinding(
+ *     scope = AppScope::class,
+ *     replaces = [RealAuthenticator::class]
+ * )
+ * class FakeAuthenticator : Authenticator
+ * ```
  */
 @Target(CLASS)
 @Repeatable
@@ -82,4 +95,10 @@ public annotation class ContributesBinding(
      * annotated with `@IntoSet`.
      */
     val multibinding: Boolean = false,
+    /**
+     * This contributed binding will replace these contributed classes. The array is allowed to
+     * include other contributed bindings and contributed component interfaces. All replaced
+     * classes must use the same scope.
+     */
+    val replaces: Array<KClass<*>> = [],
 )

--- a/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesTo.kt
+++ b/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesTo.kt
@@ -11,6 +11,18 @@ import kotlin.reflect.KClass
  * @ContributesTo(AppScope::class)
  * interface ComponentInterface { .. }
  * ```
+ *
+ * ## Replacement
+ *
+ * Component interfaces can replace other component interfaces with the [replaces] parameter.
+ * This is especially helpful for components interfaces providing different bindings in tests.
+ * ```
+ * @ContributesTo(
+ *     scope = AppScope::class,
+ *     replaces = [ComponentInterface::class],
+ * )
+ * interface TestComponentInterface { .. }
+ * ```
  */
 @Target(CLASS)
 public annotation class ContributesTo(
@@ -18,4 +30,10 @@ public annotation class ContributesTo(
      * The scope in which to include this contributed component interface.
      */
     val scope: KClass<*>,
+    /**
+     * This contributed component will replace these contributed classes. The array is allowed to
+     * include other contributed bindings and component interfaces. All replaced classes must
+     * use the same scope.
+     */
+    val replaces: Array<KClass<*>> = [],
 )


### PR DESCRIPTION
This change adds the `replaces` attribute in `@ContributesBinding` and `@ContributesTo`. It allows one contributed type to replace other contributed types.

Fixes #79