### PR TITLE
Create @ContributesAssistedFactory annotation for assisted injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,37 @@ interface RendererComponent {
 For more details on usage of the annotation and behavior
 [see the documentation](runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesSubcomponent.kt).
 
+#### `@ContributesAssistedFactory`
+
+The `@ContributesAssistedFactory` annotation allows you to bind a factory interface to a dependency 
+that uses [assisted injection from kotlin-inject](https://github.com/evant/kotlin-inject?tab=readme-ov-file#function-support--assisted-injection).
+
+```kotlin
+interface MovieRepository {
+    fun get(): Movie
+
+    interface Factory {
+        fun create(id: String): MovieRepository
+    }
+}
+
+@Inject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = MovieRepository.Factory::class,
+)
+class RealMovieRepository(
+    @Assisted private val id: String,
+) : MovieRepository
+
+@MergeComponent(AppScope::class)
+@SingleIn(AppScope::class)
+abstract class AppComponent {
+    // Will bind the factory to the component.
+    abstract val movieFactory: MovieRepository.Factory
+}
+```
+
 ### Merging
 
 With `kotlin-inject`, components are defined similar to the one below in order to instantiate your

--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/KotlinInjectExtensionSymbolProcessorProvider.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/KotlinInjectExtensionSymbolProcessorProvider.kt
@@ -4,6 +4,7 @@ import com.google.auto.service.AutoService
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
+import software.amazon.lastmile.kotlin.inject.anvil.processor.ContributesAssistedFactoryProcessor
 import software.amazon.lastmile.kotlin.inject.anvil.processor.ContributesBindingProcessor
 import software.amazon.lastmile.kotlin.inject.anvil.processor.ContributesSubcomponentFactoryProcessor
 import software.amazon.lastmile.kotlin.inject.anvil.processor.ContributesSubcomponentProcessor
@@ -39,6 +40,12 @@ class KotlinInjectExtensionSymbolProcessorProvider : SymbolProcessorProvider {
             )
             addIfEnabled(
                 ContributesBindingProcessor(
+                    codeGenerator = environment.codeGenerator,
+                    logger = environment.logger,
+                ),
+            )
+            addIfEnabled(
+                ContributesAssistedFactoryProcessor(
                     codeGenerator = environment.codeGenerator,
                     logger = environment.logger,
                 ),

--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesAssistedFactoryProcessor.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesAssistedFactoryProcessor.kt
@@ -1,0 +1,390 @@
+@file:OptIn(KspExperimental::class)
+
+package software.amazon.lastmile.kotlin.inject.anvil.processor
+
+import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.getConstructors
+import com.google.devtools.ksp.isAnnotationPresent
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.symbol.ClassKind
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSValueParameter
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.LambdaTypeName
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
+import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.toTypeName
+import com.squareup.kotlinpoet.ksp.writeTo
+import me.tatarka.inject.annotations.Assisted
+import me.tatarka.inject.annotations.Provides
+import software.amazon.lastmile.kotlin.inject.anvil.ContextAware
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesAssistedFactory
+import software.amazon.lastmile.kotlin.inject.anvil.LOOKUP_PACKAGE
+import software.amazon.lastmile.kotlin.inject.anvil.addOriginAnnotation
+import software.amazon.lastmile.kotlin.inject.anvil.requireQualifiedName
+import kotlin.reflect.KClass
+
+internal class ContributesAssistedFactoryProcessor(
+    private val codeGenerator: CodeGenerator,
+    override val logger: KSPLogger,
+) : SymbolProcessor, ContextAware {
+
+    private val anyFqName = Any::class.requireQualifiedName()
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        resolver
+            .getSymbolsWithAnnotation(ContributesAssistedFactory::class)
+            .filterIsInstance<KSClassDeclaration>()
+            .onEach {
+                checkIsPublic(it)
+                checkHasScope(it)
+            }
+            .forEach {
+                generateComponentInterface(it)
+            }
+
+        return emptyList()
+    }
+
+    @Suppress("LongMethod")
+    private fun generateComponentInterface(clazz: KSClassDeclaration) {
+        val componentClassName = ClassName(LOOKUP_PACKAGE, clazz.safeClassName)
+
+        val constructor = clazz.getConstructors().firstOrNull { constructor ->
+            constructor.parameters.any { it.isAnnotationPresent(Assisted::class) }
+        } ?: throw IllegalArgumentException(
+            "No constructor with @Assisted found in ${clazz.simpleName.asString()}",
+        )
+        val constructorParameters = constructor.parameters
+
+        val realAssistedFactory: LambdaTypeName = createRealAssistedFactory(
+            constructorParameters = constructorParameters,
+            clazz = clazz,
+        )
+
+        val annotations = clazz.findAnnotationsAtLeastOne(ContributesAssistedFactory::class)
+        checkNoDuplicateBoundTypes(clazz, annotations)
+
+        val assistedFactoryType = assistedFactoryFromAnnotation(annotations.first())
+        checkIsSingleMethodInterface(assistedFactoryType)
+
+        val generatedFunction = annotations.first().let {
+            GeneratedFunction(
+                boundType = getSingleMethodReturnType(assistedFactoryType)!!,
+                assistedFactory = assistedFactoryFromAnnotation(it),
+            )
+        }
+
+        val fileSpec = FileSpec.builder(componentClassName)
+            .apply {
+                addImport(
+                    generatedFunction.bindingMethodReturnType.packageName,
+                    generatedFunction.bindingMethodReturnType.simpleName,
+                )
+                addImport(
+                    generatedFunction.assistedFactoryReturnType.packageName,
+                    generatedFunction.assistedFactoryReturnType.simpleNames.joinToString("."),
+                )
+            }
+            .addType(
+                createComponent(
+                    componentClassName = componentClassName,
+                    clazz = clazz,
+                    function = generatedFunction,
+                    realAssistedFactory = realAssistedFactory,
+                    constructorParameters = constructorParameters,
+                ),
+            )
+            .build()
+
+        fileSpec.writeTo(codeGenerator, aggregating = false)
+    }
+
+    private fun createComponent(
+        componentClassName: ClassName,
+        clazz: KSClassDeclaration,
+        function: GeneratedFunction,
+        realAssistedFactory: LambdaTypeName,
+        constructorParameters: List<KSValueParameter>,
+    ): TypeSpec = TypeSpec
+        .interfaceBuilder(componentClassName)
+        .addOriginatingKSFile(clazz.requireContainingFile())
+        .addOriginAnnotation(clazz)
+        .addFunction(
+            FunSpec
+                .builder(
+                    "provide${clazz.innerClassNames()}" +
+                        function.bindingMethodReturnType.simpleName,
+                )
+                .addAnnotation(Provides::class)
+                .apply {
+                    addParameter(
+                        ParameterSpec.builder(
+                            "realFactory",
+                            realAssistedFactory,
+                        ).build(),
+                    )
+                    addStatement(
+                        """
+                        return Default${function.assistedFactoryReturnType.simpleName}(
+                            realFactory = realFactory
+                        )
+                        """.trimIndent(),
+                    )
+                }
+                .returns(function.assistedFactoryReturnType)
+                .build(),
+        )
+        .addType(
+            createDefaultAssistedFactory(
+                realAssistedFactory = realAssistedFactory,
+                boundAssistedFactory = function.assistedFactoryReturnType,
+                bindingMethodReturnType = function.bindingMethodReturnType,
+                assistedFactoryFunctionName = function.assistedFactoryFunctionName,
+                constructorParameters = constructorParameters,
+            ),
+        )
+        .build()
+
+    /**
+     * Create a lambda to represent the assisted factory provided by kotlin-inject.
+     *
+     * When marking an injectable class with @Assisted, kotlin-inject will generate a binding in
+     * lambda form to inject something that can create an instance.
+     */
+    private fun createRealAssistedFactory(
+        constructorParameters: List<KSValueParameter>,
+        clazz: KSClassDeclaration,
+    ): LambdaTypeName = LambdaTypeName.get(
+        parameters = constructorParameters
+            .filter { it.isAnnotationPresent(Assisted::class) }
+            .map { it.type.toTypeName() }
+            .toTypedArray(),
+        returnType = clazz.toClassName(),
+    )
+
+    /**
+     * Create a default assisted factory concreate class that implements the assisted factory
+     * interface provided in the @ContributesAssistedFactory annotation.
+     */
+    private fun createDefaultAssistedFactory(
+        realAssistedFactory: LambdaTypeName,
+        boundAssistedFactory: ClassName,
+        bindingMethodReturnType: ClassName,
+        assistedFactoryFunctionName: String,
+        constructorParameters: List<KSValueParameter>,
+    ): TypeSpec {
+        return TypeSpec.classBuilder("Default${boundAssistedFactory.simpleName}")
+            .addModifiers(KModifier.PRIVATE)
+            .primaryConstructor(
+                FunSpec.constructorBuilder()
+                    .addParameter(
+                        ParameterSpec.builder("realFactory", realAssistedFactory).build(),
+                    )
+                    .build(),
+            )
+            .addProperty(
+                PropertySpec.builder(
+                    "realFactory",
+                    realAssistedFactory,
+                )
+                    .initializer("realFactory")
+                    .addModifiers(KModifier.PRIVATE)
+                    .build(),
+            )
+            .addSuperinterface(boundAssistedFactory)
+            .addFunction(
+                FunSpec.builder(assistedFactoryFunctionName)
+                    .addModifiers(KModifier.OVERRIDE)
+                    .addParameters(
+                        constructorParameters
+                            .filter { it.isAnnotationPresent(Assisted::class) }
+                            .map { param ->
+                                val paramName = param.name!!.asString()
+                                val paramType = param.type.resolve().toTypeName()
+                                ParameterSpec.builder(paramName, paramType).build()
+                            },
+                    )
+                    .addStatement(
+                        "return realFactory(${
+                            constructorParameters.filter {
+                                it.isAnnotationPresent(
+                                    Assisted::class,
+                                )
+                            }.joinToString { it.name!!.asString() }
+                        })",
+                    )
+                    .returns(bindingMethodReturnType)
+                    .build(),
+
+            )
+            .build()
+    }
+
+    private fun checkNoDuplicateBoundTypes(
+        clazz: KSClassDeclaration,
+        annotations: List<KSAnnotation>,
+    ) {
+        annotations
+            .mapNotNull { boundTypeFromAssistedFactory(it) }
+            .map { it.declaration.requireQualifiedName() }
+            .takeIf { it.isNotEmpty() }
+            ?.reduce { previous, next ->
+                check(previous != next, clazz) {
+                    "The same type should not be contributed twice: $next."
+                }
+
+                previous
+            }
+    }
+
+    private fun boundTypeFromAssistedFactory(annotation: KSAnnotation): KSType? {
+        return annotation.arguments.firstOrNull { it.name?.asString() == "boundType" }
+            ?.let { it.value as? KSType }
+            ?.takeIf {
+                it.declaration.requireQualifiedName() != Unit::class.requireQualifiedName()
+            }
+    }
+
+    private fun assistedFactoryFromAnnotation(annotation: KSAnnotation): KSType {
+        return annotation.arguments.firstOrNull { it.name?.asString() == "assistedFactory" }
+            ?.let { it.value as? KSType }
+            ?.takeIf {
+                it.declaration.requireQualifiedName() != Unit::class.requireQualifiedName()
+            } ?: throw IllegalArgumentException(
+            "Assisted factory type must be specified in " +
+                "the @ContributesAssistedFactory annotation.",
+        )
+    }
+
+    private fun KSClassDeclaration.getAssistedFactoryInterfaceFunctions() = getAllFunctions()
+        .filterNot {
+            val simpleName = it.simpleName.asString()
+            simpleName == "equals" || simpleName == "hashCode" || simpleName == "toString"
+        }
+        .toList()
+
+    private fun checkIsSingleMethodInterface(type: KSType) {
+        val declaration = type.declaration
+        if (declaration is KSClassDeclaration && declaration.classKind == ClassKind.INTERFACE) {
+            val methods = declaration.getAssistedFactoryInterfaceFunctions()
+            check(methods.size == 1) {
+                "The assisted factory must have exactly one method."
+            }
+        } else {
+            throw IllegalArgumentException("The assisted factory must be an interface.")
+        }
+    }
+
+    private fun getSingleMethodReturnType(type: KSType): KSType? {
+        val declaration = type.declaration
+        if (declaration is KSClassDeclaration) {
+            val methods = declaration.getAssistedFactoryInterfaceFunctions()
+            if (methods.size == 1) {
+                return methods[0].returnType?.resolve()
+            }
+        }
+        return null
+    }
+
+    @Suppress("ReturnCount")
+    private fun boundType(
+        clazz: KSClassDeclaration,
+        annotation: KSAnnotation,
+    ): KSType {
+        boundTypeFromAssistedFactory(annotation)?.let { return it }
+
+        // The bound type is not defined in the annotation, let's inspect the super types.
+        val superTypes = clazz.superTypes
+            .map { it.resolve() }
+            .filter { it.declaration.requireQualifiedName() != anyFqName }
+            .toList()
+
+        when (superTypes.size) {
+            0 -> {
+                val message = "The bound type could not be determined for " +
+                    "${clazz.simpleName.asString()}. There are no super types."
+                logger.error(message, clazz)
+                throw IllegalArgumentException(message)
+            }
+
+            1 -> {
+                return superTypes.single()
+            }
+
+            else -> {
+                val message = "The bound type could not be determined for " +
+                    "${clazz.simpleName.asString()}. There are multiple super types: " +
+                    superTypes.joinToString { it.declaration.simpleName.asString() } +
+                    "."
+                logger.error(message, clazz)
+                throw IllegalArgumentException(message)
+            }
+        }
+    }
+
+    private fun KSClassDeclaration.findAnnotationsAtLeastOne(
+        annotation: KClass<out Annotation>,
+    ): List<KSAnnotation> {
+        return findAnnotations(annotation).also {
+            check(it.isNotEmpty(), this) {
+                "Couldn't find the @${annotation.simpleName} annotation for $this."
+            }
+        }
+    }
+
+    private inner class GeneratedFunction(
+        boundType: KSType,
+        assistedFactory: KSType,
+    ) {
+        val bindingMethodReturnType: ClassName by lazy {
+            boundType.toClassName()
+        }
+        val assistedFactoryReturnType: ClassName by lazy {
+            if (assistedFactory.declaration.parentDeclaration != null) {
+                val parentClassName =
+                    buildClassName(assistedFactory.declaration as KSClassDeclaration)
+                ClassName(parentClassName.packageName, parentClassName.simpleNames)
+            } else {
+                assistedFactory.toClassName()
+            }
+        }
+
+        val assistedFactoryFunctionName: String by lazy {
+            val classDeclaration = assistedFactory.declaration as? KSClassDeclaration
+                ?: throw IllegalArgumentException(
+                    "Assisted factory type must be a class.",
+                )
+            classDeclaration.getAllFunctions()
+                .map(KSFunctionDeclaration::simpleName)
+                .map { it.asString() }
+                .first()
+        }
+
+        private fun buildClassName(declaration: KSClassDeclaration): ClassName {
+            val parent = declaration.parentDeclaration
+            return if (parent is KSClassDeclaration) {
+                val parentClassName = buildClassName(parent)
+                ClassName(
+                    parentClassName.packageName,
+                    parentClassName.simpleNames + declaration.simpleName.asString(),
+                )
+            } else {
+                ClassName(declaration.packageName.asString(), declaration.simpleName.asString())
+            }
+        }
+    }
+}

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesAssistedFactoryProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesAssistedFactoryProcessorTest.kt
@@ -1,0 +1,166 @@
+@file:OptIn(ExperimentalCompilerApi::class)
+
+package software.amazon.lastmile.kotlin.inject.anvil.processor
+
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEqualTo
+import assertk.assertions.isTrue
+import com.tschuchort.compiletesting.JvmCompilationResult
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.jupiter.api.Test
+import software.amazon.lastmile.kotlin.inject.anvil.LOOKUP_PACKAGE
+import software.amazon.lastmile.kotlin.inject.anvil.compile
+import software.amazon.lastmile.kotlin.inject.anvil.componentInterface
+import software.amazon.lastmile.kotlin.inject.anvil.generatedComponent
+import software.amazon.lastmile.kotlin.inject.anvil.kotlinInjectComponent
+import software.amazon.lastmile.kotlin.inject.anvil.newComponent
+import software.amazon.lastmile.kotlin.inject.anvil.origin
+
+class ContributesAssistedFactoryProcessorTest {
+    @Test
+    fun `a component interface is generated with contributes assisted factory`() {
+        compile(
+            """
+            package software.amazon.test
+    
+            import software.amazon.lastmile.kotlin.inject.anvil.ContributesAssistedFactory
+            import me.tatarka.inject.annotations.Inject
+            import me.tatarka.inject.annotations.Assisted
+
+            interface Base
+
+            @Inject
+            @ContributesAssistedFactory(
+                scope = Unit::class,
+                assistedFactory = BaseFactory::class,
+            )
+            class Impl(
+                @Assisted val id: String,
+            ) : Base   
+
+            interface BaseFactory {
+                fun create(id: String): Base
+            }
+            """,
+        ) {
+            val component = impl.generatedComponent
+
+            assertThat(component.packageName).isEqualTo(LOOKUP_PACKAGE)
+            assertThat(component.origin).isEqualTo(impl)
+
+            val method = component.declaredMethods.single()
+            assertThat(component.declaredMethods).hasSize(1)
+            assertThat(method.returnType).isEqualTo(baseFactory)
+            assertThat(method.name).isEqualTo("provideImplBase")
+
+            val parameter = method.parameters.single()
+            assertThat(method.parameters.size).isEqualTo(1)
+            assertThat(parameter.type).isEqualTo(realAssistedFactory)
+        }
+    }
+
+    @Test
+    fun `a component interface is generated with contributes assisted factory as nested interface`() {
+        compile(
+            """
+            package software.amazon.test
+    
+            import software.amazon.lastmile.kotlin.inject.anvil.ContributesAssistedFactory
+            import me.tatarka.inject.annotations.Inject
+            import me.tatarka.inject.annotations.Assisted
+
+            interface Base {
+                interface Factory {
+                    fun create(id: String): Base
+                }
+            }
+
+            @Inject
+            @ContributesAssistedFactory(
+                scope = Unit::class,
+                assistedFactory = Base.Factory::class,
+            )
+            class Impl(
+                @Assisted val id: String,
+            ) : Base
+            """,
+        ) {
+            val component = impl.generatedComponent
+
+            assertThat(component.packageName).isEqualTo(LOOKUP_PACKAGE)
+            assertThat(component.origin).isEqualTo(impl)
+
+            val method = component.declaredMethods.single()
+            assertThat(component.declaredMethods).hasSize(1)
+            assertThat(method.returnType).isEqualTo(nestedBaseFactory)
+            assertThat(method.name).isEqualTo("provideImplBase")
+
+            val parameter = method.parameters.single()
+            assertThat(method.parameters.size).isEqualTo(1)
+            assertThat(parameter.type).isEqualTo(realAssistedFactory)
+        }
+    }
+
+    @Test
+    fun `the kotlin-inject component contains assisted factory binding`() {
+        compile(
+            """
+            package software.amazon.test
+    
+            import software.amazon.lastmile.kotlin.inject.anvil.ContributesAssistedFactory
+            import me.tatarka.inject.annotations.Inject
+            import me.tatarka.inject.annotations.Assisted
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+            import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
+
+            interface Base
+
+            @Inject
+            @ContributesAssistedFactory(
+                scope = AppScope::class,
+                assistedFactory = BaseFactory::class,
+            )
+            class Impl(
+                @Assisted val id: String,
+            ) : Base   
+
+            interface BaseFactory {
+                fun create(id: String): Base
+            }
+
+            @MergeComponent(AppScope::class)
+            @SingleIn(AppScope::class)
+            interface ComponentInterface {
+                val baseFactory: BaseFactory
+            }
+            """,
+        ) {
+            val component = componentInterface.kotlinInjectComponent.newComponent<Any>()
+
+            val implValue = component::class.java.methods
+                .single { it.name == "provideImplBase" }
+                .invoke(component, { id: String -> })
+
+            assertThat(defaultBaseFactory.isInstance(implValue)).isTrue()
+        }
+    }
+
+    private val JvmCompilationResult.baseFactory: Class<*>
+        get() = classLoader.loadClass("software.amazon.test.BaseFactory")
+
+    private val JvmCompilationResult.nestedBaseFactory: Class<*>
+        get() = classLoader.loadClass("software.amazon.test.Base${'$'}Factory")
+
+    private val JvmCompilationResult.defaultBaseFactory: Class<*>
+        get() = classLoader.loadClass(
+            "amazon.lastmile.inject.SoftwareAmazonTestImpl${'$'}DefaultBaseFactory",
+        )
+
+    private val JvmCompilationResult.impl: Class<*>
+        get() = classLoader.loadClass("software.amazon.test.Impl")
+
+    private val JvmCompilationResult.realAssistedFactory: Class<*>
+        get() = classLoader.loadClass("kotlin.jvm.functions.Function1")
+}

--- a/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesAssistedFactory.kt
+++ b/runtime/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContributesAssistedFactory.kt
@@ -1,0 +1,66 @@
+package software.amazon.lastmile.kotlin.inject.anvil
+
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.reflect.KClass
+
+/**
+ * Generates a component interface for an annotated class and contributes a binding method to
+ * the given [scope]. Imagine this example:
+ * ```
+ * interface MovieRepository
+ *
+ * interface MovieRepositoryFactory {
+ *     fun create(id: String): MovieRepository
+ * }
+ *
+ * @Inject
+ * @SingleIn(AppScope::class)
+ * class MovieRepositoryImpl(
+ *      @Assisted val id: String,
+ * ) : MovieRepository
+ *
+ * @Inject
+ * @ContributesBinding(AppScope::class)
+ * @SingleIn(AppScope::class)
+ * class DefaultMovieRepositoryFactory(
+ *      private val realFactory: (String) -> MovieRepositoryImpl,
+ * ) : MovieRepositoryFactory {
+ *     override fun create(id: String): MovieRepository = realFactory(id)
+ * }
+ * ```
+ *
+ * This is a lot of boilerplate any time you want to use assisted injection providing a
+ * factory interface. You can eliminate the default factory class and replace it with the
+ * [ContributesAssistedFactory] annotation. The equivalent would be:
+ *
+ * ```
+ * interface MovieRepository
+ *
+ * interface MovieRepositoryFactory {
+ *     fun create(id: String): MovieRepository
+ * }
+ *
+ * @Inject
+ * @ContributesAssistedFactory(
+ *    scope = AppScope::class,
+ *    assistedFactory = MovieRepositoryFactory::class,
+ * )
+ * @SingleIn(AppScope::class)
+ * class MovieRepositoryImpl(
+ *      @Assisted val id: String,
+ * ) : MovieRepository
+ * ```
+ */
+@Target(CLASS)
+@Repeatable
+public annotation class ContributesAssistedFactory(
+    /**
+     * The scope in which to include this contributed binding.
+     */
+    val scope: KClass<*>,
+
+    /**
+     * The assisted factory that will be used to create instances of the bound type.
+     */
+    val assistedFactory: KClass<*>,
+)


### PR DESCRIPTION
Issue #92 

*Description of changes:*

Today if you want to use assisted injection and bind a factory interface to create the dependency, you would have to do the following.

```kotlin
interface MovieRepository

interface MovieRepositoryFactory {
    fun create(id: String): MovieRepository
}

@Inject
@SingleIn(AppScope::class)
class MovieRepositoryImpl(
     @Assisted val id: String,
) : MovieRepository

@Inject
@ContributesBinding(AppScope::class)
@SingleIn(AppScope::class)
class DefaultMovieRepositoryFactory(
     private val realFactory: (String) -> MovieRepositoryImpl,
) : MovieRepositoryFactory {
    override fun create(id: String): MovieRepository = realFactory(id)
}
```

In the journey of trying to add assisted injection to kotlin-inject-anvil, I originally tried to add support for this to the `@ContributesBinding` in the following PR. 

* https://github.com/amzn/kotlin-inject-anvil/pull/104

However I came across another library for the original anvil library called [anvil-utils](https://github.com/IlyaGulya/anvil-utils?tab=readme-ov-file#usage) that provided an api to bind assisted factory interfaces to dependencies that are assisted injected. So I attempted to do something similar by creating a new annotation called `@ContributesAssistedFactory` which will allow a factory interface to be bound in the graph for a dependency that needs to be assisted injection. It will generate a default class that implements the factory interface and then binds that to real factory interface that kotlin-inject binds which is just a lambda. The usage of this new annotation: 

```kotlin
interface MovieRepository

interface MovieRepositoryFactory {
    fun create(id: String): MovieRepository
}

@Inject
@ContributesAssistedFactory(
   scope = AppScope::class,
   assistedFactory = MovieRepositoryFactory::class,
)
@SingleIn(AppScope::class)
class MovieRepositoryImpl(
     @Assisted val id: String,
) : MovieRepository
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
