### PR TITLE
Remove retention annotation

### DIFF
--- a/runtime-optional/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ForScope.kt
+++ b/runtime-optional/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ForScope.kt
@@ -1,7 +1,6 @@
 package software.amazon.lastmile.kotlin.inject.anvil
 
 import me.tatarka.inject.annotations.Qualifier
-import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.annotation.AnnotationTarget.FUNCTION
 import kotlin.annotation.AnnotationTarget.PROPERTY
@@ -28,7 +27,6 @@ import kotlin.reflect.KClass
  * therefore the same annotation can be used for Dagger 2 and Anvil.
  */
 @Qualifier
-@Retention(RUNTIME)
 @Target(CLASS, FUNCTION, PROPERTY_GETTER, VALUE_PARAMETER, TYPE, PROPERTY)
 public expect annotation class ForScope(
     /**

--- a/runtime-optional/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/SingleIn.kt
+++ b/runtime-optional/src/commonMain/kotlin/software/amazon/lastmile/kotlin/inject/anvil/SingleIn.kt
@@ -1,7 +1,6 @@
 package software.amazon.lastmile.kotlin.inject.anvil
 
 import me.tatarka.inject.annotations.Scope
-import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.annotation.AnnotationTarget.FUNCTION
 import kotlin.annotation.AnnotationTarget.PROPERTY_GETTER
@@ -23,7 +22,6 @@ import kotlin.reflect.KClass
  * therefore the same annotation can be used for Dagger 2 and Anvil.
  */
 @Scope
-@Retention(RUNTIME)
 @Target(CLASS, FUNCTION, PROPERTY_GETTER, VALUE_PARAMETER)
 public expect annotation class SingleIn(
     /**

--- a/runtime-optional/src/jvmAndAndroid/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ForScope.kt
+++ b/runtime-optional/src/jvmAndAndroid/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ForScope.kt
@@ -1,6 +1,5 @@
 package software.amazon.lastmile.kotlin.inject.anvil
 
-import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.annotation.AnnotationTarget.FUNCTION
 import kotlin.annotation.AnnotationTarget.PROPERTY
@@ -28,7 +27,6 @@ import kotlin.reflect.KClass
  */
 @me.tatarka.inject.annotations.Qualifier
 @javax.inject.Qualifier
-@Retention(RUNTIME)
 @Target(CLASS, FUNCTION, PROPERTY_GETTER, VALUE_PARAMETER, TYPE, PROPERTY)
 public actual annotation class ForScope(
     /**

--- a/runtime-optional/src/jvmAndAndroid/kotlin/software/amazon/lastmile/kotlin/inject/anvil/SingleIn.kt
+++ b/runtime-optional/src/jvmAndAndroid/kotlin/software/amazon/lastmile/kotlin/inject/anvil/SingleIn.kt
@@ -1,6 +1,5 @@
 package software.amazon.lastmile.kotlin.inject.anvil
 
-import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.annotation.AnnotationTarget.FUNCTION
 import kotlin.annotation.AnnotationTarget.PROPERTY_GETTER
@@ -23,7 +22,6 @@ import kotlin.reflect.KClass
  */
 @me.tatarka.inject.annotations.Scope
 @javax.inject.Scope
-@Retention(RUNTIME)
 @Target(CLASS, FUNCTION, PROPERTY_GETTER, VALUE_PARAMETER)
 public actual annotation class SingleIn(
     /**

--- a/runtime-optional/src/nonJvmAndAndroid/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ForScope.kt
+++ b/runtime-optional/src/nonJvmAndAndroid/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ForScope.kt
@@ -1,7 +1,6 @@
 package software.amazon.lastmile.kotlin.inject.anvil
 
 import me.tatarka.inject.annotations.Qualifier
-import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.annotation.AnnotationTarget.FUNCTION
 import kotlin.annotation.AnnotationTarget.PROPERTY
@@ -25,7 +24,6 @@ import kotlin.reflect.KClass
  * ```
  */
 @Qualifier
-@Retention(RUNTIME)
 @Target(CLASS, FUNCTION, PROPERTY_GETTER, VALUE_PARAMETER, TYPE, PROPERTY)
 public actual annotation class ForScope(
     /**

--- a/runtime-optional/src/nonJvmAndAndroid/kotlin/software/amazon/lastmile/kotlin/inject/anvil/SingleIn.kt
+++ b/runtime-optional/src/nonJvmAndAndroid/kotlin/software/amazon/lastmile/kotlin/inject/anvil/SingleIn.kt
@@ -1,7 +1,6 @@
 package software.amazon.lastmile.kotlin.inject.anvil
 
 import me.tatarka.inject.annotations.Scope
-import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.annotation.AnnotationTarget.FUNCTION
 import kotlin.annotation.AnnotationTarget.PROPERTY_GETTER
@@ -20,7 +19,6 @@ import kotlin.reflect.KClass
  * ```
  */
 @Scope
-@Retention(RUNTIME)
 @Target(CLASS, FUNCTION, PROPERTY_GETTER, VALUE_PARAMETER)
 public actual annotation class SingleIn(
     /**


### PR DESCRIPTION
The default retention for annotations is Runtime and this doesn't need to be declared. By explicitly adding the annotation downstream projects using JS or WasmJS as target run into https://youtrack.jetbrains.com/issue/KT-41082/KJS-Reflection-is-not-supported-on-JavaScript-target-so-you-wont-be-able-to-read-this-annotation-in-runtime-warning-is Removing the annotation avoids this issue.
