### PR TITLE
Delete unnecessary isQualifier method and use isKotlinInjectQualifierAnnotation instead

### DIFF
--- a/compiler-utils/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContextAware.kt
+++ b/compiler-utils/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/ContextAware.kt
@@ -1,7 +1,9 @@
 package software.amazon.lastmile.kotlin.inject.anvil
 
+import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.getDeclaredFunctions
 import com.google.devtools.ksp.getVisibility
+import com.google.devtools.ksp.isAnnotationPresent
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.ClassKind
@@ -29,7 +31,6 @@ interface ContextAware {
     val logger: KSPLogger
 
     private val scopeFqName get() = Scope::class.requireQualifiedName()
-    private val qualifierFqName get() = Qualifier::class.requireQualifiedName()
     private val componentFqName get() = Component::class.requireQualifiedName()
 
     fun <T : Any> requireNotNull(
@@ -112,10 +113,9 @@ interface ContextAware {
         return annotationType.resolve().isKotlinInjectQualifierAnnotation()
     }
 
+    @OptIn(KspExperimental::class)
     private fun KSType.isKotlinInjectQualifierAnnotation(): Boolean {
-        return declaration.annotations.any {
-            it.annotationType.resolve().declaration.requireQualifiedName() == qualifierFqName
-        }
+        return declaration.isAnnotationPresent(Qualifier::class)
     }
 
     fun KSAnnotation.isKotlinInjectComponentAnnotation(): Boolean {

--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesBindingProcessor.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/ContributesBindingProcessor.kt
@@ -28,7 +28,6 @@ import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
 import me.tatarka.inject.annotations.IntoSet
 import me.tatarka.inject.annotations.Provides
-import me.tatarka.inject.annotations.Qualifier
 import software.amazon.lastmile.kotlin.inject.anvil.ContextAware
 import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
 import software.amazon.lastmile.kotlin.inject.anvil.LOOKUP_PACKAGE
@@ -126,7 +125,7 @@ internal class ContributesBindingProcessor(
                                 .addAnnotation(Provides::class)
                                 .apply {
                                     clazz.annotations
-                                        .filter { it.isQualifier() }
+                                        .filter { it.isKotlinInjectQualifierAnnotation() }
                                         .forEach { qualifier ->
                                             addAnnotation(qualifier.toAnnotationSpec())
                                         }
@@ -165,12 +164,6 @@ internal class ContributesBindingProcessor(
 
         fileSpec.writeTo(codeGenerator, aggregating = false)
     }
-
-    @OptIn(KspExperimental::class)
-    private fun KSAnnotation.isQualifier(): Boolean =
-        annotationType.resolve().declaration.isAnnotationPresent(
-            Qualifier::class,
-        )
 
     private fun FunSpec.Builder.createNormalProvider(clazz: KSClassDeclaration) {
         val parameterName = clazz.innerClassNames().decapitalize()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


Tiny follow up to #114

Stumbled upon `ContextAware` earlier when starting to write my own extension and realized there was already a way to detect qualifiers 🙈 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
