### PR TITLE
fix: Skip unresolvable contributions in MergeComponentProcessor

### DIFF
--- a/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/MergeComponentProcessor.kt
+++ b/compiler/src/main/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/MergeComponentProcessor.kt
@@ -174,6 +174,22 @@ internal class MergeComponentProcessor(
                     origin.requireQualifiedName() !in excludeNames
                 }
             }
+            .filter { contributedInterface ->
+                // Skip contributions whose origin references types unavailable on the current
+                // compilation target (e.g. JVM-only supertypes when compiling for JS).
+                contributedInterface.originChain().all { origin ->
+                    val resolvable = origin.superTypes.all { ref ->
+                        !ref.resolve().isError
+                    }
+                    if (!resolvable) {
+                        logger.warn(
+                            "Skipping ${origin.requireQualifiedName()}: " +
+                                "has unresolvable supertypes on this target.",
+                        )
+                    }
+                    resolvable
+                }
+            }
             .filter {
                 !it.isAnnotationPresent(Subcomponent::class) ||
                     it.contributedSubcomponent().requireQualifiedName() !in excludeNames

--- a/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/MergeComponentProcessorTest.kt
+++ b/compiler/src/test/kotlin/software/amazon/lastmile/kotlin/inject/anvil/processor/MergeComponentProcessorTest.kt
@@ -685,6 +685,88 @@ class MergeComponentProcessorTest {
         }
     }
 
+    @Test
+    fun `contributions with unresolvable supertypes are skipped`() {
+        // Round 1: compile a base type that will become
+        // "unavailable" in the final round.
+        val round1 = compile(
+            """
+            package software.amazon.test
+
+            interface JvmOnlyBase
+            """,
+        )
+
+        // Round 2: compile a @ContributesTo interface that
+        // extends JvmOnlyBase.  The KSP processor generates
+        // a lookup-package interface with @Origin.
+        val round2 = compile(
+            """
+            package software.amazon.test
+
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+            import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
+
+            @ContributesTo(AppScope::class)
+            interface HasJvmSuper : JvmOnlyBase
+            """,
+            previousCompilationResult = round1,
+        )
+
+        // Round 3: compile the @MergeComponent with only
+        // round 2 on the classpath. JvmOnlyBase (from round 1)
+        // is NOT on this classpath, so HasJvmSuper's supertype
+        // resolves as an error type — the filter must skip it.
+        compile(
+            """
+            package software.amazon.test
+
+            import me.tatarka.inject.annotations.Component
+            import me.tatarka.inject.annotations.Provides
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+            import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
+            import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
+            import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
+
+            @ContributesTo(AppScope::class)
+            interface StringComponent {
+                @Provides fun provideString(): String = "abc"
+            }
+
+            @Component
+            @MergeComponent(AppScope::class)
+            @SingleIn(AppScope::class)
+            abstract class ComponentInterface :
+                ComponentInterfaceMerged {
+                abstract val string: String
+            }
+            """,
+            allWarningsAsErrors = false,
+            previousCompilationResult = round2,
+        ) {
+            // StringComponent should be merged.
+            assertThat(
+                stringComponent.isAssignableFrom(
+                    componentInterface,
+                ),
+            ).isTrue()
+
+            // The merged interface should only list
+            // StringComponent (from the current round),
+            // not the unresolvable HasJvmSuper contribution.
+            val merged = componentInterface.mergedComponent
+            val superNames = merged.interfaces
+                .map { it.name }
+            assertThat(superNames).contains(
+                "$LOOKUP_PACKAGE" +
+                    ".SoftwareAmazonTestStringComponent",
+            )
+            assertThat(
+                superNames.any { "HasJvmSuper" in it },
+            ).isFalse()
+        }
+    }
+
     private val JvmCompilationResult.stringComponent: Class<*>
         get() = classLoader.loadClass("software.amazon.test.StringComponent")
 


### PR DESCRIPTION
## Summary

- Fix `MergeComponentProcessor` to skip contributions whose supertypes cannot be resolved, instead of failing with an error
- This allows `@MergeComponent` to work on JS/WASM targets where some platform-specific contributions are not available

Fixes #125

## Test plan

- [x] Existing tests pass
- [x] Verified JS browser app compiles and runs with `@MergeComponent` using this fix